### PR TITLE
feat(primitives): added null object

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-stryker": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "commands": [
         "dotnet-stryker"
       ]

--- a/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
+++ b/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
@@ -1,6 +1,6 @@
 namespace Off.Net.Pdf.Core.Interfaces;
 
-public interface IPdfObject<T>
+public interface IPdfObject
 {
     /// <summary>
     /// Gets the length of the object.
@@ -8,12 +8,15 @@ public interface IPdfObject<T>
     int Length { get; }
 
     /// <summary>
-    /// Gets or sets the value of the object.
-    /// </summary>
-    T Value { get; }
-
-    /// <summary>
     /// Gets the bytes array representation of the Pdf object.
     /// </summary>
     byte[] Bytes { get; }
+}
+
+public interface IPdfObject<out T> : IPdfObject
+{
+    /// <summary>
+    /// Gets or sets the value of the object.
+    /// </summary>
+    T Value { get; }
 }

--- a/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
@@ -1,0 +1,36 @@
+using System.Text;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.Primitives;
+
+public struct PdfNull : IPdfObject
+{
+    #region Fields
+    private const string literalValue = "null";
+    private static readonly int hashCode = HashCode.Combine(nameof(PdfNull).GetHashCode(), literalValue.GetHashCode());
+    private static readonly byte[] bytes = Encoding.ASCII.GetBytes(literalValue);
+    #endregion
+
+    #region Properties
+    public int Length => ToString().Length;
+
+    public byte[] Bytes => bytes;
+    #endregion
+
+    #region Public Methods
+    public override string ToString()
+    {
+        return literalValue;
+    }
+
+    public override int GetHashCode()
+    {
+        return hashCode;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PdfNull;
+    }
+    #endregion
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
@@ -1,0 +1,106 @@
+using System;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Primitives;
+
+public class PdfNullTests
+{
+    [Fact(DisplayName = "Check the length of the PDF null primitive")]
+    public void PdfNull_Length_CheckValue()
+    {
+        // Arrange
+        PdfNull pdfNull = new PdfNull();
+
+        // Act
+        float actualLength = pdfNull.Length;
+
+        // Assert
+        Assert.Equal(4, actualLength);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfNull_Equals_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfNull pdfNull1 = new PdfNull();
+
+        // Act
+        bool actualResult = pdfNull1.Equals(null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method with object type as an argument")]
+    public void PdfNull_Equality_CheckEquals()
+    {
+        // Arrange
+        PdfNull pdfNull1 = new PdfNull();
+        PdfNull pdfNull2 = new PdfNull();
+
+        // Act
+        bool actualResult = pdfNull1.Equals((object)pdfNull2);
+
+        // Assert
+        Assert.True(actualResult);
+    }
+
+    [Fact(DisplayName = "Check if Bytes property returns valid data")]
+    public void PdfNull_Bytes_CheckValidity()
+    {
+        // Arrange
+        byte[] expectedBytes = new byte[] { 110, 117, 108, 108 };
+        PdfNull pdfNull1 = new PdfNull();
+
+        // Act
+        byte[] actualBytes = pdfNull1.Bytes;
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    [Fact(DisplayName = "Check if GetHashCode method returns valid value")]
+    public void PdfNull_GetHashCode_CheckValidity()
+    {
+        // Arrange
+        PdfNull pdfNull1 = new PdfNull();
+        float expectedHashCode = HashCode.Combine(nameof(PdfNull).GetHashCode(), "null");
+
+        // Act
+        float actualHashCode = pdfNull1.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Fact(DisplayName = "Compare the hash codes of two integer objects.")]
+    public void PdfNull_GetHashCode_CompareHashes()
+    {
+        // Arrange
+        PdfNull pdfNull1 = new PdfNull();
+        PdfNull pdfNull2 = new PdfNull();
+
+        // Act
+        float actualHashCode1 = pdfNull1.GetHashCode();
+        float actualHashCode2 = pdfNull2.GetHashCode();
+        bool areHashCodeEquals = actualHashCode1 == actualHashCode2;
+
+        // Assert
+        Assert.True(areHashCodeEquals);
+    }
+
+    [Fact(DisplayName = "Check ToString method for equality")]
+    public void PdfNull_ToString_CheckEquality()
+    {
+        // Arrange
+        PdfNull pdfNull1 = new PdfNull();
+        const string expectedStringValue = "null";
+
+        // Act
+        string actualPdfNullStringValue = pdfNull1.ToString();
+
+        // Assert
+        Assert.Equal(expectedStringValue, actualPdfNullStringValue);
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.3.9`, the null object has a type and value that are unequal to those of any other object.

There shall be only one object of type null, denoted by the keyword `null`. An indirect object reference to a nonexistent object shall be treated the same as a null object. Specifying the null object as the value of a dictionary entry shall be equivalent to omitting the entry entirely.

### Acceptance criteria

1. Create a `PdfNull` struct.
2. Implement the `IPdfObject` interface.
3. Override the `GetHashCode` and `ToString` methods.
4. Create implicit operators.
6. Cover the primitive implementation with the unit and mutation tests.