### PR TITLE
feature(primitives): added name object

### DIFF
--- a/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
@@ -3,8 +3,7 @@ namespace Off.Net.Pdf.Core.Primitives;
 using System.Text;
 using Off.Net.Pdf.Core.Interfaces;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S1210:\"Equals\" and the comparison operators should be overridden when implementing \"IComparable\"", Justification = "Other operators, except == and !=, are not required.")]
-public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>, IComparable, IComparable<PdfBoolean>
+public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>
 {
     #region Fields
     private readonly string stringValue;
@@ -51,37 +50,17 @@ public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>, IComparable
     {
         return (obj is PdfBoolean booleanObject) && Equals(booleanObject);
     }
-
-    public int CompareTo(PdfBoolean other)
-    {
-        if (Value == other.Value)
-        {
-            return 0;
-        }
-
-        return Value ? 1 : -1;
-    }
-
-    public int CompareTo(object? obj)
-    {
-        if (obj is not PdfBoolean pdfBoolean)
-        {
-            throw new ArgumentException(Resource.Arg_MustBePdfBoolean);
-        }
-
-        return CompareTo(pdfBoolean);
-    }
     #endregion
 
     #region Operators
     public static bool operator ==(PdfBoolean leftOperator, PdfBoolean rightOperator)
     {
-        return leftOperator.CompareTo(rightOperator) == 0;
+        return leftOperator.Equals(rightOperator);
     }
 
     public static bool operator !=(PdfBoolean leftOperator, PdfBoolean rightOperator)
     {
-        return leftOperator.CompareTo(rightOperator) != 0;
+        return !leftOperator.Equals(rightOperator);
     }
 
     public static implicit operator bool(PdfBoolean pdfBoolean)

--- a/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
@@ -1,0 +1,127 @@
+using System.Globalization;
+using System.Text;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.Primitives;
+
+public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
+{
+    #region Fields
+    private const string NumberChar = "#23"; // '#'
+    private const string SolidusChar = "#2F"; // '/'
+    private const string PercentChar = "#25"; // '/'
+    private const string LeftParanthesisChar = "#28"; // '('
+    private const string RightParanthesisChar = "#29"; // ')'
+    private const string GreaterThanChar = "#3E"; // '>'
+    private const string LessThanChar = "#3C"; // '<'
+    private const string LeftSquareBracketChar = "#5B"; // '['
+    private const string RightSquareBracketChar = "#5D"; // ']'
+    private const string LeftCurlyBracketChar = "#7B"; // '{'
+    private const string RightCurlyBracketChar = "#7D"; // '}'
+    private readonly int hashCode;
+    private string literalValue = string.Empty;
+    private byte[]? bytes;
+    #endregion
+
+    #region Constructors
+    public PdfName(string value)
+    {
+        Value = value;
+        hashCode = HashCode.Combine(nameof(PdfName).GetHashCode(), value.GetHashCode());
+        bytes = null;
+    }
+    #endregion
+
+    #region Properties
+    public int Length => ToString().Length;
+
+    public string Value { get; }
+
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    #endregion
+
+    #region Public Methods
+    public override string ToString()
+    {
+        if (literalValue.Length != 0)
+        {
+            return literalValue;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        foreach (char ch in Value)
+        {
+            stringBuilder.Append(ConvertCharToString(ch));
+        }
+
+        literalValue = stringBuilder.ToString();
+        return literalValue;
+    }
+
+    public override int GetHashCode()
+    {
+        return hashCode;
+    }
+
+    public bool Equals(PdfName? other)
+    {
+        if (other is not PdfName pdfName)
+        {
+            return false;
+        }
+
+        return Value == pdfName.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return (obj is PdfName pdfName) && Equals(pdfName);
+    }
+
+    #endregion
+
+    #region Operators
+    public static bool operator ==(PdfName leftOperator, PdfName rightOperator)
+    {
+        return leftOperator.Equals(rightOperator);
+    }
+
+    public static bool operator !=(PdfName leftOperator, PdfName rightOperator)
+    {
+        return !leftOperator.Equals(rightOperator);
+    }
+
+    public static implicit operator string(PdfName pdfName)
+    {
+        return pdfName.Value;
+    }
+
+    public static implicit operator PdfName(string value)
+    {
+        return new(value);
+    }
+    #endregion
+
+    #region Private Methods
+    private static string ConvertCharToString(char ch)
+    {
+        return ch switch
+        {
+            '#' => NumberChar,
+            '/' => SolidusChar,
+            '%' => PercentChar,
+            '(' => LeftParanthesisChar,
+            ')' => RightParanthesisChar,
+            '>' => GreaterThanChar,
+            '<' => LessThanChar,
+            '[' => LeftSquareBracketChar,
+            ']' => RightSquareBracketChar,
+            '{' => LeftCurlyBracketChar,
+            '}' => RightCurlyBracketChar,
+            char regularChar when regularChar <= 0x20 || regularChar >= 0x7F => $"#{Convert.ToByte(ch).ToString("X2", CultureInfo.InvariantCulture)}",
+            _ => ch.ToString(),
+        };
+    }
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
@@ -63,17 +63,17 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
 
     public override bool Equals(object? obj)
     {
-        return (obj is PdfReal integerObject) && Equals(integerObject);
+        return (obj is PdfReal pdfReal) && Equals(pdfReal);
     }
 
     public int CompareTo(object? obj)
     {
-        if (obj is not PdfReal pdfInteger)
+        if (obj is not PdfReal pdfReal)
         {
             throw new ArgumentException(Resource.Arg_MustBePdfReal);
         }
 
-        return CompareTo(pdfInteger);
+        return CompareTo(pdfReal);
     }
 
     public int CompareTo(PdfReal other)
@@ -118,9 +118,9 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
         return leftOperator.CompareTo(rightOperator) >= 0;
     }
 
-    public static implicit operator float(PdfReal pdfInteger)
+    public static implicit operator float(PdfReal pdfReal)
     {
-        return pdfInteger.Value;
+        return pdfReal.Value;
     }
 
     public static implicit operator PdfReal(float value)

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
@@ -18,7 +18,7 @@ public class PdfBooleanTests
         Assert.False(pdfBoolean1.Value);
     }
 
-    [Theory(DisplayName = "Create a instance using parametrized constructor and check the Value property")]
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
     [InlineData(true)]
     [InlineData(false)]
     public void PdfBoolean_ParameterizedContructor_CheckValue(bool value)
@@ -187,38 +187,6 @@ public class PdfBooleanTests
 
         // Assert
         Assert.Equal(expectedValue, actualValue);
-    }
-
-    [Theory(DisplayName = "Check CompareTo method")]
-    [InlineData(false, false, 0)]
-    [InlineData(false, true, -1)]
-    [InlineData(true, false, 1)]
-    [InlineData(true, true, 0)]
-    public void PdfBoolean_CompareTo_CheckValidity(bool value1, bool value2, int expectedValue)
-    {
-        // Arrange
-        var pdfBoolean1 = new PdfBoolean(value1);
-        object pdfBoolean2 = new PdfBoolean(value2);
-
-        // Act
-        int actualValue = pdfBoolean1.CompareTo(pdfBoolean2);
-
-        // Assert
-        Assert.Equal(expectedValue, actualValue);
-    }
-
-    [Fact(DisplayName = "Check CompareTo method should throw an exception")]
-    public void PdfBoolean_CompareTo_ThrowsException()
-    {
-        // Arrange
-        var pdfBoolean1 = new PdfBoolean();
-        object pdfBoolean2 = 5;
-
-        // Act
-        Action actualValueDelegate = () => pdfBoolean1.CompareTo(pdfBoolean2);
-
-        // Assert
-        Assert.Throws<ArgumentException>(actualValueDelegate);
     }
 
     [Theory(DisplayName = "Check ToString method for equality")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
@@ -18,7 +18,7 @@ public class PdfIntegerTests
         Assert.Equal(0, pdfInteger1.Value);
     }
 
-    [Theory(DisplayName = "Create a instance using parametrized constructor and check the Value property")]
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
     [InlineData(123)]
     [InlineData(43445)]
     [InlineData(+17)]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
@@ -1,0 +1,272 @@
+using System;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Primitives;
+
+public class PdfNameTests
+{
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
+    [InlineData("Name1", "Name1")]
+    [InlineData("ASomewhatLongerName", "ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?", "A;Name_With-Various***Characters?")]
+    [InlineData("1.2", "1.2")]
+    [InlineData("$$", "$$")]
+    [InlineData("@pattern", "@pattern")]
+    [InlineData(".notdef", ".notdef")]
+    [InlineData("Lime Green", "Lime Green")]
+    [InlineData("paired()parentheses", "paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor", "The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus", "/NameWithSolidus")]
+    public void PdfName_ParameterizedContructor_CheckValue(string inputValue, string expectedValue)
+    {
+        // Arrange
+        PdfName pdfName = inputValue; // Use an implicit conversion from string to PdfName
+
+        // Act
+
+        // Assert
+        Assert.Equal(expectedValue, pdfName.Value);
+    }
+
+    [Theory(DisplayName = "Check the length of the PDF name primitive")]
+    [InlineData("Name1", 5)]
+    [InlineData("ASomewhatLongerName", 19)]
+    [InlineData("A;Name_With-Various***Characters?", 33)]
+    [InlineData("1.2", 3)]
+    [InlineData("$$", 2)]
+    [InlineData("@pattern", 8)]
+    [InlineData(".notdef", 7)]
+    [InlineData("Lime Green", 12)]
+    [InlineData("paired()parentheses", 23)]
+    [InlineData("The_Key_of_F#_Minor", 21)]
+    [InlineData("/NameWithSolidus", 18)]
+    public void PdfName_Length_CheckValue(string value, int expectedLength)
+    {
+        // Arrange
+        PdfName pdfName = value; // Use an implicit conversion from string to PdfName
+
+        // Act
+        int actualLength = pdfName.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfName_Equals_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfName pdfName1 = "Name1"; // Use an implicit conversion from string to PdfName
+
+        // Act
+        bool actualResult = pdfName1.Equals(null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfName_Equals2_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfName pdfName1 = "Name1"; // Use an implicit conversion from string to PdfName
+
+        // Act
+        bool actualResult = pdfName1.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Theory(DisplayName = "Check Equals method with object type as an argument")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "\\Name1", false)]
+    public void PdfName_Equality_CheckEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+        PdfName pdfName2 = value2; // Use an implicit conversion from string to PdfName
+
+        // Act
+        bool actualResult = pdfName1.Equals((object)pdfName2);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory(DisplayName = "Check if Bytes property returns valid data")]
+    [InlineData("Name1", new byte[] { 78, 97, 109, 101, 49 })]
+    [InlineData("ASomewhatLongerName", new byte[] { 65, 83, 111, 109, 101, 119, 104, 97, 116, 76, 111, 110, 103, 101, 114, 78, 97, 109, 101 })]
+    [InlineData("A;Name_With-Various***Characters?", new byte[] { 65, 59, 78, 97, 109, 101, 95, 87, 105, 116, 104, 45, 86, 97, 114, 105, 111, 117, 115, 42, 42, 42, 67, 104, 97, 114, 97, 99, 116, 101, 114, 115, 63 })]
+    [InlineData("1.2", new byte[] { 49, 46, 50 })]
+    [InlineData("$$", new byte[] { 36, 36 })]
+    [InlineData("@pattern", new byte[] { 64, 112, 97, 116, 116, 101, 114, 110 })]
+    [InlineData(".notdef", new byte[] { 46, 110, 111, 116, 100, 101, 102 })]
+    [InlineData("Lime Green", new byte[] { 76, 105, 109, 101, 35, 50, 48, 71, 114, 101, 101, 110 })]
+    [InlineData("paired()parentheses", new byte[] { 112, 97, 105, 114, 101, 100, 35, 50, 56, 35, 50, 57, 112, 97, 114, 101, 110, 116, 104, 101, 115, 101, 115 })]
+    [InlineData("The_Key_of_F#_Minor", new byte[] { 84, 104, 101, 95, 75, 101, 121, 95, 111, 102, 95, 70, 35, 50, 51, 95, 77, 105, 110, 111, 114 })]
+    [InlineData("/NameWithSolidus", new byte[] { 35, 50, 70, 78, 97, 109, 101, 87, 105, 116, 104, 83, 111, 108, 105, 100, 117, 115 })]
+    public void PdfName_Bytes_CheckValidity(string value1, byte[] expectedBytes)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+
+        // Act
+        byte[] actualBytes = pdfName1.Bytes;
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [InlineData("Name1")]
+    [InlineData("ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?")]
+    [InlineData("1.2")]
+    [InlineData("$$")]
+    [InlineData("@pattern")]
+    [InlineData(".notdef")]
+    [InlineData("Lime Green")]
+    [InlineData("paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus")]
+    public void PdfName_GetHashCode_CheckValidity(string value1)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+        int expectedHashCode = HashCode.Combine(nameof(PdfName).GetHashCode(), value1.GetHashCode());
+
+        // Act
+        int actualHashCode = pdfName1.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Theory(DisplayName = "Compare the hash codes of two name objects.")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "\\Name1", false)]
+    public void PdfName_GetHashCode_CompareHashes(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+        PdfName pdfName2 = value2; // Use an implicit conversion from string to PdfName
+
+        // Act
+        int actualHashCode1 = pdfName1.GetHashCode();
+        int actualHashCode2 = pdfName2.GetHashCode();
+        bool areHashCodeEquals = actualHashCode1 == actualHashCode2;
+
+        // Assert
+        Assert.Equal(expectedResult, areHashCodeEquals);
+    }
+
+    [Theory(DisplayName = "Check if comparison operators works properly")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "\\Name1", false)]
+    public void PdfName_Operators_CheckEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+        PdfName pdfName2 = value2; // Use an implicit conversion from string to PdfName
+
+        // Act
+        bool actualEqual = pdfName1 == pdfName2;
+
+        // Assert
+        Assert.Equal(actualEqual, expectedResult);
+    }
+
+    [Theory(DisplayName = "Check if comparison operators works properly")]
+    [InlineData("Name1", "Name1", false)]
+    [InlineData("Name1", "name1", true)]
+    [InlineData("Name1", "\\Name1", true)]
+    public void PdfName_Operators_CheckNotEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+        PdfName pdfName2 = value2; // Use an implicit conversion from string to PdfName
+
+        // Act
+        bool actualEqual = pdfName1 != pdfName2;
+
+        // Assert
+        Assert.Equal(actualEqual, expectedResult);
+    }
+
+    [Theory(DisplayName = "Check if implicit operator works")]
+    [InlineData("Name1")]
+    [InlineData("ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?")]
+    [InlineData("1.2")]
+    [InlineData("$$")]
+    [InlineData("@pattern")]
+    [InlineData(".notdef")]
+    [InlineData("Lime Green")]
+    [InlineData("paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus")]
+    public void PdfName_CheckImplicitOperator(string value1)
+    {
+        // Arrange
+        var pdfName1 = new PdfName(value1);
+
+        // Act
+        string actualValue = pdfName1; // Use an implicit conversion from PdfName to string
+        string expectedValue = pdfName1.Value;
+
+        // Assert
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Theory(DisplayName = "Check ToString method for equality")]
+    [InlineData("Name1", "Name1")]
+    [InlineData("ASomewhatLongerName", "ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?", "A;Name_With-Various***Characters?")]
+    [InlineData("1.2", "1.2")]
+    [InlineData("$$", "$$")]
+    [InlineData("@pattern", "@pattern")]
+    [InlineData(".notdef", ".notdef")]
+    [InlineData("Lime Green", "Lime#20Green")]
+    [InlineData("paired()parentheses", "paired#28#29parentheses")]
+    [InlineData("The_Key_of_F#_Minor", "The_Key_of_F#23_Minor")]
+    [InlineData("/NameWithSolidus", "#2FNameWithSolidus")]
+    [InlineData("NameWith%Percent", "NameWith#25Percent")]
+    [InlineData("NameWith>GreaterThanChar", "NameWith#3EGreaterThanChar")]
+    [InlineData("NameWith<LessThanChar", "NameWith#3CLessThanChar")]
+    [InlineData("NameWith[LeftSquareBracket", "NameWith#5BLeftSquareBracket")]
+    [InlineData("NameWith]RightSquareBracket", "NameWith#5DRightSquareBracket")]
+    [InlineData("NameWith{LeftCurlyBracket", "NameWith#7BLeftCurlyBracket")]
+    [InlineData("NameWith}RightCurlyBracket", "NameWith#7DRightCurlyBracket")]
+    [InlineData("NameWith\x007FDeleteChar", "NameWith#7FDeleteChar")]
+    public void PdfName_ToString_CheckEquality(string value1, string expectedPdfNameStringValue)
+    {
+        // Arrange
+        PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
+
+        // Act
+        string actualPdfNameStringValue = pdfName1.ToString();
+
+        // Assert
+        Assert.Equal(expectedPdfNameStringValue, actualPdfNameStringValue);
+    }
+
+    [Fact(DisplayName = "Check ToString method for multiple accessing")]
+    public void PdfName_ToString_CheckMultipleAccessing()
+    {
+        // Arrange
+        PdfName pdfName1 = "CustomName"; // Use an implicit conversion from string to PdfName
+
+        // Act
+        string firstString = pdfName1.ToString();
+        string secondString = pdfName1.ToString();
+
+        // Assert
+        Assert.Equal(firstString, secondString);
+        Assert.True(ReferenceEquals(firstString, secondString));
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
@@ -18,7 +18,7 @@ public class PdfRealTests
         Assert.Equal(0, pdfReal1.Value);
     }
 
-    [Theory(DisplayName = "Create a instance using parametrized constructor and check the Value property")]
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
     [InlineData(34.5)]
     [InlineData(-3.62)]
     [InlineData(+123.6)] // Plus sign is automatically removed by C#.
@@ -124,7 +124,7 @@ public class PdfRealTests
         Assert.Equal(expectedHashCode, actualHashCode);
     }
 
-    [Theory(DisplayName = "Compare the hash codes of two integer objects.")]
+    [Theory(DisplayName = "Compare the hash codes of two real objects.")]
     [InlineData(34.5, 34.5, true)]
     [InlineData(0.0, -0.000, true)]
     [InlineData(-3.62, 3.62, false)]


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.3.5`, the Name object represents an atomic symbol uniquely defined by a sequence of any characters 8-bit values) except `null` (character code 0).

Annex C describes that the maximum length of a name, in bytes, should be `127`. The limit applies to the number 
of characters in the name’s internal representation. For example, the name `/A#20B` has three characters (A, SPACE, B), not six.

Example of PDF names:

| Syntax for Literal name | Resulting name |
|---|---|
| /MyName1 | MyName1 |
| /Name_With_Underscores-Dashes-And;Semicolons;Chars | Name_With_Underscores-Dashes-And;Semicolons;Chars |
| /Name#20With#20Spaces | Name With Spaces |
| /A#42C | /ABC |

### Acceptance criteria

1. Create a `PdfName` class.
2. Implement the `IPdfObject`, `IEquatable` interfaces.
3. Override the `GetHashCode` and `ToString` methods.
4. Create `==`, `!=`, and implicit operators.
5. Add the architectural limits described above.
6. Cover the primitive implementation with the unit, mutation, and benchmark tests.
7. The output of creating the `Name` object should be a string representation preceded by a `slash` sign (`0x2F`) and the name itself. The chars in the name should be represented as literal or hex representation, following these rules:

| Char Code | Literal | Hex |
|---|:---:|:---:|
| 0x0 - 0x20 |  | :white_check_mark: |
| 0x21 - 0x7E | :white_check_mark: | :white_check_mark: |
| 0x7F - 0xFF |  | :white_check_mark: |