### PR TITLE
feat(primitives): added string object

### DIFF
--- a/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
@@ -63,7 +63,7 @@ public struct PdfInteger : IPdfObject<int>, IEquatable<PdfInteger>, IComparable,
     {
         if (obj is not PdfInteger pdfInteger)
         {
-            throw new ArgumentException(Resource.Arg_MustBePdfInteger);
+            throw new ArgumentException(Resource.PdfInteger_MustBePdfInteger);
         }
 
         return CompareTo(pdfInteger);

--- a/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
@@ -70,7 +70,7 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
     {
         if (obj is not PdfReal pdfReal)
         {
-            throw new ArgumentException(Resource.Arg_MustBePdfReal);
+            throw new ArgumentException(Resource.PdfReal_MustBePdfReal);
         }
 
         return CompareTo(pdfReal);

--- a/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
@@ -1,0 +1,228 @@
+using System.Text;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.Primitives;
+
+public sealed class PdfString : IPdfObject<string>, IEquatable<PdfString>
+{
+    #region Fields
+    private readonly int hashCode;
+    private readonly bool isHexString;
+    private string literalValue = string.Empty;
+    private byte[]? bytes;
+    #endregion
+
+    #region Constructors
+    public PdfString(string value) : this(value, false)
+    {
+    }
+
+    public PdfString(string value, bool isHexString)
+    {
+        ThrowExceptionIfValueIsNotValid(value, isHexString);
+        Value = value;
+        hashCode = HashCode.Combine(nameof(PdfString).GetHashCode(), value.GetHashCode());
+        bytes = null;
+        this.isHexString = isHexString;
+    }
+    #endregion
+
+    #region Properties
+    public int Length => ToString().Length;
+
+    public string Value { get; }
+
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    #endregion
+
+    #region Public Methods
+    public override string ToString()
+    {
+        if (literalValue.Length != 0)
+        {
+            return literalValue;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (int i = 0; i < Value.Length; i++)
+        {
+            stringBuilder.Append(Value[i]);
+        }
+
+        literalValue = stringBuilder
+            .Insert(0, isHexString ? '<' : '(')
+            .Append(isHexString ? '>' : ')')
+            .ToString();
+
+        return literalValue;
+    }
+
+    public override int GetHashCode()
+    {
+        return hashCode;
+    }
+
+    public bool Equals(PdfString? other)
+    {
+        if (other is not PdfString pdfName)
+        {
+            return false;
+        }
+
+        return Value == pdfName.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return (obj is PdfString pdfName) && Equals(pdfName);
+    }
+
+    #endregion
+
+    #region Operators
+    public static bool operator ==(PdfString leftOperator, PdfString rightOperator)
+    {
+        return leftOperator.Equals(rightOperator);
+    }
+
+    public static bool operator !=(PdfString leftOperator, PdfString rightOperator)
+    {
+        return !leftOperator.Equals(rightOperator);
+    }
+
+    public static implicit operator string(PdfString pdfName)
+    {
+        return pdfName.Value;
+    }
+
+    public static implicit operator PdfString(string value)
+    {
+        return new(value);
+    }
+    #endregion
+
+    #region Private Methods
+    private static void ThrowExceptionIfValueIsNotValid(string value, bool isHexString)
+    {
+        if (!isHexString)
+        {
+            ValidateStringValue(value);
+            return;
+        }
+
+        ValidateHexValue(value);
+    }
+
+    private static void ValidateStringValue(string value)
+    {
+        if (!ContainsUnbalancedParentheses(value))
+        {
+            throw new ArgumentException(Resource.PdfString_MustHaveBalancedParentheses, nameof(value));
+        }
+
+        if (!ContainsValidSolidusChars(value))
+        {
+            throw new ArgumentException(Resource.PdfString_MustHaveValidSolidusChars, nameof(value));
+        }
+    }
+
+    private static void ValidateHexValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentNullException(nameof(value), Resource.PdfString_MustNotBeEmpty);
+        }
+
+        if (!IsValidHexValue(value))
+        {
+            throw new ArgumentException(Resource.PdfString_MustHaveValidHexValue, nameof(value));
+        }
+    }
+
+    private static bool ContainsUnbalancedParentheses(string value)
+    {
+        int parenthesesBalance = 0;
+
+        foreach (char ch in value)
+        {
+            if (parenthesesBalance < 0)
+            {
+                return false;
+            }
+
+            if (ch == '(')
+            {
+                parenthesesBalance++;
+                continue;
+            }
+
+            if (ch == ')')
+            {
+                parenthesesBalance--;
+            }
+        }
+
+        return parenthesesBalance == 0;
+    }
+
+    private static bool ContainsValidSolidusChars(string value)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '\\')
+            {
+                continue;
+            }
+
+            int nextIndex = i + 1;
+            if (nextIndex == value.Length)
+            {
+                return false;
+            }
+
+            if (!IsValidNextCharAfterSolidus(value[nextIndex]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidNextCharAfterSolidus(char ch)
+    {
+        return ch switch
+        {
+            '\\' or '(' or ')' or '\n' or '\r' or '\t' or '\b' or '\f' => true,
+            char numberChar when numberChar >= '0' && numberChar <= '9' => true,
+            _ => false,
+        };
+    }
+
+    private static bool IsValidHexValue(string value)
+    {
+        foreach (char ch in value)
+        {
+            if (!IsValidHexChar(ch))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidHexChar(char ch)
+    {
+        return ch switch
+        {
+            char letterChar when letterChar >= 'a' && letterChar <= 'f' => true,
+            char capitalLetterChar when capitalLetterChar >= 'A' && capitalLetterChar <= 'F' => true,
+            char numberChar when numberChar >= '0' && numberChar <= '9' => true,
+            ' ' or '\t' or '\r' or '\n' or '\f' => true,
+            _ => false
+        };
+    }
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -61,29 +61,56 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object must be a PDF Boolean type.
+        ///   Looks up a localized string similar to The object must be a PDF Integer type.
         /// </summary>
-        internal static string Arg_MustBePdfBoolean {
+        internal static string PdfInteger_MustBePdfInteger {
             get {
-                return ResourceManager.GetString("Arg_MustBePdfBoolean", resourceCulture);
+                return ResourceManager.GetString("PdfInteger_MustBePdfInteger", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object must be a PDF Integer type.
+        ///   Looks up a localized string similar to The object must be a PDF Real type.
         /// </summary>
-        internal static string Arg_MustBePdfInteger {
+        internal static string PdfReal_MustBePdfReal {
             get {
-                return ResourceManager.GetString("Arg_MustBePdfInteger", resourceCulture);
+                return ResourceManager.GetString("PdfReal_MustBePdfReal", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Object must be a PDF Real type.
+        ///   Looks up a localized string similar to The PDF string type must have balanced parentheses.
         /// </summary>
-        internal static string Arg_MustBePdfReal {
+        internal static string PdfString_MustHaveBalancedParentheses {
             get {
-                return ResourceManager.GetString("Arg_MustBePdfReal", resourceCulture);
+                return ResourceManager.GetString("PdfString_MustHaveBalancedParentheses", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The object must be a PDF String type with a valid Hex value.
+        /// </summary>
+        internal static string PdfString_MustHaveValidHexValue {
+            get {
+                return ResourceManager.GetString("PdfString_MustHaveValidHexValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The PDF string type must have valid solidus characters.
+        /// </summary>
+        internal static string PdfString_MustHaveValidSolidusChars {
+            get {
+                return ResourceManager.GetString("PdfString_MustHaveValidSolidusChars", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The PDF string type with Hex representation should have a value provided.
+        /// </summary>
+        internal static string PdfString_MustNotBeEmpty {
+            get {
+                return ResourceManager.GetString("PdfString_MustNotBeEmpty", resourceCulture);
             }
         }
     }

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -117,13 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Arg_MustBePdfBoolean" xml:space="preserve">
-    <value>Object must be a PDF Boolean type</value>
+  <data name="PdfInteger_MustBePdfInteger" xml:space="preserve">
+    <value>The object must be a PDF Integer type</value>
   </data>
-  <data name="Arg_MustBePdfInteger" xml:space="preserve">
-    <value>Object must be a PDF Integer type</value>
+  <data name="PdfReal_MustBePdfReal" xml:space="preserve">
+    <value>The object must be a PDF Real type</value>
   </data>
-  <data name="Arg_MustBePdfReal" xml:space="preserve">
-    <value>Object must be a PDF Real type</value>
+  <data name="PdfString_MustHaveBalancedParentheses" xml:space="preserve">
+    <value>The PDF string type must have balanced parentheses</value>
+  </data>
+  <data name="PdfString_MustHaveValidHexValue" xml:space="preserve">
+    <value>The object must be a PDF String type with a valid Hex value</value>
+  </data>
+  <data name="PdfString_MustHaveValidSolidusChars" xml:space="preserve">
+    <value>The PDF string type must have valid solidus characters</value>
+  </data>
+  <data name="PdfString_MustNotBeEmpty" xml:space="preserve">
+    <value>The PDF string type with Hex representation should have a value provided</value>
   </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
@@ -1,0 +1,324 @@
+using System;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Primitives;
+
+public class PdfStringTests
+{
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
+    [InlineData("Name1", "Name1")]
+    [InlineData("ASomewhatLongerName", "ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?", "A;Name_With-Various***Characters?")]
+    [InlineData("1.2", "1.2")]
+    [InlineData("$$", "$$")]
+    [InlineData("@pattern", "@pattern")]
+    [InlineData(".notdef", ".notdef")]
+    [InlineData("Lime Green", "Lime Green")]
+    [InlineData("paired()parentheses", "paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor", "The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus", "/NameWithSolidus")]
+    public void PdfString_ParameterizedContructor_CheckValue(string inputValue, string expectedValue)
+    {
+        // Arrange
+        PdfString pdfString = inputValue; // Use an implicit conversion from string to PdfString
+
+        // Act
+
+        // Assert
+        Assert.Equal(expectedValue, pdfString.Value);
+    }
+
+    [Theory(DisplayName = "Check the length of the PDF name primitive")]
+    [InlineData("Name1", false, 7)] // 5 characters + 2 parentheses
+    [InlineData("ASomewhatLongerName", false, 21)] // 19 characters + 2 parentheses
+    [InlineData("A;Name_With-Various***Characters?", false, 35)] // 33 characters + 2 parentheses
+    [InlineData("1.2", false, 5)] // 3 characters + 2 parentheses
+    [InlineData("$$", false, 4)] // 2 characters + 2 parentheses
+    [InlineData("@pattern", false, 10)] // 8 characters + 2 parentheses
+    [InlineData(".notdef", false, 9)] // 7 characters + 2 parentheses
+    [InlineData("Lime Green", false, 12)] // 10 characters + 2 parentheses
+    [InlineData("paired()parentheses", false, 21)] // 19 characters + 2 parentheses
+    [InlineData("The_Key_of_F#_Minor", false, 21)] // 19 characters + 2 parentheses
+    [InlineData("/NameWithSolidus", false, 18)] // 16 characters + 2 parentheses
+    [InlineData("\t90\n1F\rA3\r\n\f", true, 14)] // 12 characters + 2 angled brackets
+    [InlineData("901FA", true, 7)] // 5 characters + 2 angled brackets
+    public void PdfString_Length_CheckValue(string value, bool isHexString, int expectedLength)
+    {
+        // Arrange
+        PdfString pdfString = new PdfString(value, isHexString);
+
+        // Act
+        int actualLength = pdfString.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfString_Equals_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfString pdfString1 = "Name1"; // Use an implicit conversion from string to PdfString
+
+        // Act
+        bool actualResult = pdfString1.Equals(null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfString_Equals2_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfString pdfString1 = "Name1"; // Use an implicit conversion from string to PdfString
+
+        // Act
+        bool actualResult = pdfString1.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Theory(DisplayName = "Check Equals method with object type as an argument")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "Name2", false)]
+    public void PdfString_Equality_CheckEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+        PdfString pdfString2 = value2; // Use an implicit conversion from string to PdfString
+
+        // Act
+        bool actualResult = pdfString1.Equals((object)pdfString2);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory(DisplayName = "Check if Bytes property returns valid data")]
+    [InlineData("Name1", new byte[] { 40, 78, 97, 109, 101, 49, 41})]
+    [InlineData("ASomewhatLongerName", new byte[] { 40, 65, 83, 111, 109, 101, 119, 104, 97, 116, 76, 111, 110, 103, 101, 114, 78, 97, 109, 101, 41 })]
+    [InlineData("A;Name_With-Various***Characters?", new byte[] { 40, 65, 59, 78, 97, 109, 101, 95, 87, 105, 116, 104, 45, 86, 97, 114, 105, 111, 117, 115, 42, 42, 42, 67, 104, 97, 114, 97, 99, 116, 101, 114, 115, 63, 41 })]
+    [InlineData("1.2", new byte[] { 40, 49, 46, 50, 41 })]
+    [InlineData("$$", new byte[] { 40, 36, 36, 41 })]
+    [InlineData("@pattern", new byte[] { 40, 64, 112, 97, 116, 116, 101, 114, 110, 41 })]
+    [InlineData(".notdef", new byte[] { 40, 46, 110, 111, 116, 100, 101, 102, 41 })]
+    [InlineData("Lime Green", new byte[] { 40, 76, 105, 109, 101, 32, 71, 114, 101, 101, 110, 41 })]
+    [InlineData("paired()parentheses", new byte[] { 40, 112, 97, 105, 114, 101, 100, 40, 41, 112, 97, 114, 101, 110, 116, 104, 101, 115, 101, 115, 41 })]
+    [InlineData("The_Key_of_F#_Minor", new byte[] { 40, 84, 104, 101, 95, 75, 101, 121, 95, 111, 102, 95, 70, 35, 95, 77, 105, 110, 111, 114, 41 })]
+    [InlineData("/NameWithSolidus", new byte[] { 40, 47, 78, 97, 109, 101, 87, 105, 116, 104, 83, 111, 108, 105, 100, 117, 115, 41 })]
+    public void PdfString_Bytes_CheckValidity(string value1, byte[] expectedBytes)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+
+        // Act
+        byte[] actualBytes = pdfString1.Bytes;
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [InlineData("Name1")]
+    [InlineData("ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?")]
+    [InlineData("1.2")]
+    [InlineData("$$")]
+    [InlineData("@pattern")]
+    [InlineData(".notdef")]
+    [InlineData("Lime Green")]
+    [InlineData("paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus")]
+    public void PdfString_GetHashCode_CheckValidity(string value1)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+        int expectedHashCode = HashCode.Combine(nameof(PdfString).GetHashCode(), value1.GetHashCode());
+
+        // Act
+        int actualHashCode = pdfString1.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Theory(DisplayName = "Compare the hash codes of two name objects.")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "Name2", false)]
+    public void PdfString_GetHashCode_CompareHashes(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+        PdfString pdfString2 = value2; // Use an implicit conversion from string to PdfString
+
+        // Act
+        int actualHashCode1 = pdfString1.GetHashCode();
+        int actualHashCode2 = pdfString2.GetHashCode();
+        bool areHashCodeEquals = actualHashCode1 == actualHashCode2;
+
+        // Assert
+        Assert.Equal(expectedResult, areHashCodeEquals);
+    }
+
+    [Theory(DisplayName = "Check if comparison operators works properly")]
+    [InlineData("Name1", "Name1", true)]
+    [InlineData("Name1", "name1", false)]
+    [InlineData("Name1", "Name2", false)]
+    public void PdfString_Operators_CheckEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+        PdfString pdfString2 = value2; // Use an implicit conversion from string to PdfString
+
+        // Act
+        bool actualEqual = pdfString1 == pdfString2;
+
+        // Assert
+        Assert.Equal(actualEqual, expectedResult);
+    }
+
+    [Theory(DisplayName = "Check if comparison operators works properly")]
+    [InlineData("Name1", "Name1", false)]
+    [InlineData("Name1", "name1", true)]
+    [InlineData("Name1", "Name2", true)]
+    public void PdfString_Operators_CheckNotEquals(string value1, string value2, bool expectedResult)
+    {
+        // Arrange
+        PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
+        PdfString pdfString2 = value2; // Use an implicit conversion from string to PdfString
+
+        // Act
+        bool actualEqual = pdfString1 != pdfString2;
+
+        // Assert
+        Assert.Equal(actualEqual, expectedResult);
+    }
+
+    [Theory(DisplayName = "Check if implicit operator works")]
+    [InlineData("Name1")]
+    [InlineData("ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?")]
+    [InlineData("1.2")]
+    [InlineData("$$")]
+    [InlineData("@pattern")]
+    [InlineData(".notdef")]
+    [InlineData("Lime Green")]
+    [InlineData("paired()parentheses")]
+    [InlineData("The_Key_of_F#_Minor")]
+    [InlineData("/NameWithSolidus")]
+    public void PdfString_CheckImplicitOperator(string value1)
+    {
+        // Arrange
+        var pdfString1 = new PdfString(value1);
+
+        // Act
+        string actualValue = pdfString1; // Use an implicit conversion from PdfString to string
+        string expectedValue = pdfString1.Value;
+
+        // Assert
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Theory(DisplayName = "Check ToString method for equality")]
+    [InlineData("This is a string", "(This is a string)", false)]
+    [InlineData("Strings may contain newlines\r\nand such.", "(Strings may contain newlines\r\nand such.)", false)]
+    [InlineData("Strings may contain balanced parentheses ( ) and\r\nspecial characters (*!&}^% and so on).", "(Strings may contain balanced parentheses ( ) and\r\nspecial characters (*!&}^% and so on).)", false)]
+    [InlineData("", "()", false)]
+    [InlineData("These \\\r\ntwo strings \\\r\nare the same.", "(These \\\r\ntwo strings \\\r\nare the same.)", false)]
+    [InlineData("These \\\ntwo strings \\\rare the same.", "(These \\\ntwo strings \\\rare the same.)", false)]
+    [InlineData("This string has an end-of-line at the end of it.\r\n", "(This string has an end-of-line at the end of it.\r\n)", false)]
+    [InlineData("So does this one.\\\n", "(So does this one.\\\n)", false)]
+    [InlineData("This string contains \\009two octal characters\\907.", "(This string contains \\009two octal characters\\907.)", false)]
+    [InlineData("4E6F762073686D6F7A206B6120706F702E", "<4E6F762073686D6F7A206B6120706F702E>", true)]
+    [InlineData("901FA3", "<901FA3>", true)]
+    [InlineData("90 1F A3", "<90 1F A3>", true)]
+    [InlineData("\t90\n1F\rA3\r\n\f", "<\t90\n1F\rA3\r\n\f>", true)] // White-spaces should be ignored in hex string
+    [InlineData("901FA", "<901FA>", true)] // If the last digit is missing, the last digit is considered 0, i.e. 901FA0
+    [InlineData("901fa", "<901fa>", true)] // If the last digit is missing, the last digit is considered 0, i.e. 901fa0
+    public void PdfString_ToString_CheckEquality(string value1, string expectedPdfStringStringValue, bool isHexValue)
+    {
+        // Arrange
+        PdfString pdfString1 = new PdfString(value1, isHexValue);
+
+        // Act
+        string actualPdfStringStringValue = pdfString1.ToString();
+
+        // Assert
+        Assert.Equal(expectedPdfStringStringValue, actualPdfStringStringValue);
+    }
+
+    [Fact(DisplayName = "Check ToString method for multiple accessing")]
+    public void PdfString_ToString_CheckMultipleAccessing()
+    {
+        // Arrange
+        PdfString pdfString1 = "CustomString"; // Use an implicit conversion from string to PdfString
+
+        // Act
+        string firstString = pdfString1.ToString();
+        string secondString = pdfString1.ToString();
+
+        // Assert
+        Assert.Equal(firstString, secondString);
+        Assert.True(ReferenceEquals(firstString, secondString));
+    }
+
+    [Theory(DisplayName = "Check if constructor will throw an exception when solidus char is not followed by newline char")]
+    [InlineData("Solidus without \\ new line symbol should throw exception.")]
+    [InlineData("Solidus without new line symbol at the end of the line.\\")]
+    public void PdfString_Constructor_SolidusCharWithoutNewLineSymbol_ShouldThrowException(string value1)
+    {
+        // Arrange
+
+        // Act
+        Action pdfStringValueDelegate = () => new PdfString(value1);
+
+        // Assert
+        Assert.Throws<ArgumentException>(pdfStringValueDelegate);
+    }
+
+    [Theory(DisplayName = "Check if string with unbalanced parentheses will throw an exception")]
+    [InlineData("Strings with unbalanced parentheses (( ( ), should throw an exception.")]
+    [InlineData("Strings with unbalanced parentheses ))((, should throw an exception.")]
+    public void PdfString_Constructor_UnbalancedParentheses_ShouldThrowException(string value1)
+    {
+        // Arrange
+
+        // Act
+        Action pdfStringValueDelegate = () => new PdfString(value1);
+
+        // Assert
+        Assert.Throws<ArgumentException>(pdfStringValueDelegate);
+    }
+
+    [Theory(DisplayName = "Check if constructor will throw an exception when invalid Hex value is provided")]
+    [InlineData("invalid_hex_chars")]
+    [InlineData("FF99H")]
+    public void PdfString_Constructor_InvalidHexValue_ShouldThrowArgumentException(string value1)
+    {
+        // Arrange
+
+        // Act
+        Action pdfStringValueDelegate = () => new PdfString(value1, true);
+
+        // Assert
+        Assert.Throws<ArgumentException>(pdfStringValueDelegate);
+    }
+
+    [Fact(DisplayName = "Check if constructor will throw an exception when invalid Hex value is provided")]
+    public void PdfString_Constructor_InvalidHexValue_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+
+        // Act
+        Action pdfStringValueDelegate = () => new PdfString(string.Empty, true);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(pdfStringValueDelegate);
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.3.4`, the String object shall consist of a series of zero or more bytes. String objects are not integer objects, but are stored in a more compact format

Annex C describes that the maximum length of a string (in the content stream), in bytes, should be `32767`.

Example of literal string:

```
(This is a string)
```

Example of hexadecimal string:

```
<4E6F762073686D6F7A206B6120706F702E>
```

### Acceptance criteria

1. Create a `PdfString` class.
2. Implement the `IPdfObject`, `IEquatable` interfaces.
3. Override the `GetHashCode` and `ToString` methods.
4. Create `==`, `!=`, and implicit operators.
5. Add the architectural limits described above.
6. Cover the primitive implementation with the unit and mutation tests.