### PR TITLE
feat(primitives): added array object

### DIFF
--- a/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
+++ b/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
@@ -11,6 +11,8 @@ public interface IPdfObject
     /// Gets the bytes array representation of the Pdf object.
     /// </summary>
     byte[] Bytes { get; }
+
+    string Content { get; }
 }
 
 public interface IPdfObject<out T> : IPdfObject

--- a/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.Primitives;
+
+public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEquatable<PdfArray?>
+{
+    #region Fields
+    private readonly int hashCode;
+    private string literalValue = string.Empty;
+    private byte[]? bytes;
+    #endregion
+
+    #region Constructors
+    public PdfArray(IReadOnlyCollection<IPdfObject> value)
+    {
+        Value = value;
+        hashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value.GetHashCode());
+        bytes = null;
+    }
+    #endregion
+
+    #region Properties
+    public int Length => Content.Length;
+
+    public IReadOnlyCollection<IPdfObject> Value { get; }
+
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(Content);
+
+    public string Content => GenerateContent();
+    #endregion
+
+    #region Public Methods
+    public override int GetHashCode()
+    {
+        return hashCode;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as PdfArray);
+    }
+
+    public bool Equals(PdfArray? other)
+    {
+        return other is not null &&
+               EqualityComparer<IReadOnlyCollection<IPdfObject>>.Default.Equals(Value, other.Value);
+    }
+
+    public static PdfArray CreateRange(IEnumerable<IPdfObject> items)
+    {
+        return new PdfArray(items.ToList());
+    }
+
+    public static PdfArray Create(IPdfObject item)
+    {
+        return new PdfArray(new List<IPdfObject>(1) { item });
+    }
+    #endregion
+
+    #region Private Methods
+    private string GenerateContent()
+    {
+        if (literalValue.Length != 0)
+        {
+            return literalValue;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        foreach (var item in Value)
+        {
+            stringBuilder
+                .Append(item.Content)
+                .Append(' ');
+        }
+
+        if (stringBuilder.Length > 0 && stringBuilder[^1] == ' ')
+        {
+            stringBuilder.Remove(stringBuilder.Length - 1, 1);
+        }
+
+        literalValue = stringBuilder
+            .Insert(0, '[')
+            .Append(']')
+            .ToString();
+
+        return literalValue;
+    }
+    #endregion
+}
+
+public static class PdfArrayExtensions
+{
+    public static PdfArray ToPdfArray(this IEnumerable<IPdfObject> items)
+    {
+        return PdfArray.CreateRange(items.ToList());
+    }
+
+    public static PdfArray ToPdfArray(this IPdfObject item)
+    {
+        return PdfArray.Create(item);
+    }
+}

--- a/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
@@ -1,14 +1,10 @@
-namespace Off.Net.Pdf.Core.Primitives;
-
 using System.Text;
 using Off.Net.Pdf.Core.Interfaces;
 
+namespace Off.Net.Pdf.Core.Primitives;
+
 public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>
 {
-    #region Fields
-    private readonly string stringValue;
-    #endregion
-
     #region Constructors
     public PdfBoolean() : this(false)
     {
@@ -17,28 +13,25 @@ public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>
     public PdfBoolean(bool value)
     {
         Value = value;
-        stringValue = value ? "true" : "false";
-        Bytes = Encoding.ASCII.GetBytes(stringValue);
+        Content = value ? "true" : "false";
+        Bytes = Encoding.ASCII.GetBytes(Content);
     }
     #endregion
 
     #region Properties
-    public int Length => stringValue.Length;
+    public int Length => Content.Length;
 
     public bool Value { get; }
 
     public byte[] Bytes { get; }
+
+    public string Content { get; }
     #endregion
 
     #region Public Methods
     public override int GetHashCode()
     {
         return HashCode.Combine(nameof(PdfBoolean).GetHashCode(), Value.GetHashCode());
-    }
-
-    public override string ToString()
-    {
-        return stringValue;
     }
 
     public bool Equals(PdfBoolean other)

--- a/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
@@ -26,24 +26,16 @@ public struct PdfInteger : IPdfObject<int>, IEquatable<PdfInteger>, IComparable,
     #endregion
 
     #region Properties
-    public int Length => ToString().Length;
+    public int Length => Content.Length;
 
     public int Value { get; }
 
-    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(Content);
+
+    public string Content => GenerateContent();
     #endregion
 
     #region Public Methods
-    public override string ToString()
-    {
-        if (literalValue.Length == 0)
-        {
-            literalValue = Value.ToString(CultureInfo.InvariantCulture);
-        }
-
-        return literalValue;
-    }
-
     public override int GetHashCode()
     {
         return hashCode;
@@ -119,6 +111,18 @@ public struct PdfInteger : IPdfObject<int>, IEquatable<PdfInteger>, IComparable,
     public static implicit operator PdfInteger(int value)
     {
         return new(value);
+    }
+    #endregion
+
+    #region Private Methods
+    private string GenerateContent()
+    {
+        if (literalValue.Length == 0)
+        {
+            literalValue = Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return literalValue;
     }
     #endregion
 }

--- a/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
@@ -26,6 +26,11 @@ public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
     #region Constructors
     public PdfName(string value)
     {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentNullException(nameof(value), Resource.PdfName_CannotBeNullOrWhitespace);
+        }
+
         Value = value;
         hashCode = HashCode.Combine(nameof(PdfName).GetHashCode(), value.GetHashCode());
         bytes = null;
@@ -33,32 +38,16 @@ public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
     #endregion
 
     #region Properties
-    public int Length => ToString().Length;
+    public int Length => Content.Length;
 
     public string Value { get; }
 
-    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(Content);
+
+    public string Content => GenerateContent();
     #endregion
 
     #region Public Methods
-    public override string ToString()
-    {
-        if (literalValue.Length != 0)
-        {
-            return literalValue;
-        }
-
-        StringBuilder stringBuilder = new StringBuilder();
-
-        foreach (char ch in Value)
-        {
-            stringBuilder.Append(ConvertCharToString(ch));
-        }
-
-        literalValue = stringBuilder.ToString();
-        return literalValue;
-    }
-
     public override int GetHashCode()
     {
         return hashCode;
@@ -104,6 +93,27 @@ public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
     #endregion
 
     #region Private Methods
+    private string GenerateContent()
+    {
+        if (literalValue.Length != 0)
+        {
+            return literalValue;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        foreach (char ch in Value)
+        {
+            stringBuilder.Append(ConvertCharToString(ch));
+        }
+
+        literalValue = stringBuilder
+            .Insert(0, '/')
+            .ToString();
+
+        return literalValue;
+    }
+
     private static string ConvertCharToString(char ch)
     {
         return ch switch

--- a/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
@@ -12,17 +12,14 @@ public struct PdfNull : IPdfObject
     #endregion
 
     #region Properties
-    public int Length => ToString().Length;
+    public int Length => 4;
 
     public byte[] Bytes => bytes;
+
+    public string Content => literalValue;
     #endregion
 
     #region Public Methods
-    public override string ToString()
-    {
-        return literalValue;
-    }
-
     public override int GetHashCode()
     {
         return hashCode;

--- a/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
@@ -33,24 +33,16 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
     #endregion
 
     #region Properties
-    public int Length => ToString().Length;
+    public int Length => Content.Length;
 
     public float Value { get; }
 
-    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(Content);
+
+    public string Content => GenerateContent();
     #endregion
 
     #region Public Methods
-    public override string ToString()
-    {
-        if (literalValue.Length == 0)
-        {
-            literalValue = Value.ToString(CultureInfo.InvariantCulture);
-        }
-
-        return literalValue;
-    }
-
     public override int GetHashCode()
     {
         return hashCode;
@@ -126,6 +118,18 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
     public static implicit operator PdfReal(float value)
     {
         return new(value);
+    }
+    #endregion
+
+    #region Private Methods
+    private string GenerateContent()
+    {
+        if (literalValue.Length == 0)
+        {
+            literalValue = Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return literalValue;
     }
     #endregion
 }

--- a/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
@@ -28,36 +28,16 @@ public sealed class PdfString : IPdfObject<string>, IEquatable<PdfString>
     #endregion
 
     #region Properties
-    public int Length => ToString().Length;
+    public int Length => Content.Length;
 
     public string Value { get; }
 
-    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(ToString());
+    public byte[] Bytes => bytes ??= Encoding.ASCII.GetBytes(Content);
+
+    public string Content => GenerateContent();
     #endregion
 
     #region Public Methods
-    public override string ToString()
-    {
-        if (literalValue.Length != 0)
-        {
-            return literalValue;
-        }
-
-        StringBuilder stringBuilder = new StringBuilder();
-
-        for (int i = 0; i < Value.Length; i++)
-        {
-            stringBuilder.Append(Value[i]);
-        }
-
-        literalValue = stringBuilder
-            .Insert(0, isHexString ? '<' : '(')
-            .Append(isHexString ? '>' : ')')
-            .ToString();
-
-        return literalValue;
-    }
-
     public override int GetHashCode()
     {
         return hashCode;
@@ -103,6 +83,28 @@ public sealed class PdfString : IPdfObject<string>, IEquatable<PdfString>
     #endregion
 
     #region Private Methods
+    private string GenerateContent()
+    {
+        if (literalValue.Length != 0)
+        {
+            return literalValue;
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (int i = 0; i < Value.Length; i++)
+        {
+            stringBuilder.Append(Value[i]);
+        }
+
+        literalValue = stringBuilder
+            .Insert(0, isHexString ? '<' : '(')
+            .Append(isHexString ? '>' : ')')
+            .ToString();
+
+        return literalValue;
+    }
+
     private static void ThrowExceptionIfValueIsNotValid(string value, bool isHexString)
     {
         if (!isHexString)

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -70,6 +70,15 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The PDF name type cannot be null or contain whitespaces.
+        /// </summary>
+        internal static string PdfName_CannotBeNullOrWhitespace {
+            get {
+                return ResourceManager.GetString("PdfName_CannotBeNullOrWhitespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The object must be a PDF Real type.
         /// </summary>
         internal static string PdfReal_MustBePdfReal {

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -120,6 +120,9 @@
   <data name="PdfInteger_MustBePdfInteger" xml:space="preserve">
     <value>The object must be a PDF Integer type</value>
   </data>
+  <data name="PdfName_CannotBeNullOrWhitespace" xml:space="preserve">
+    <value>The PDF name type cannot be null or contain whitespaces</value>
+  </data>
   <data name="PdfReal_MustBePdfReal" xml:space="preserve">
     <value>The object must be a PDF Real type</value>
   </data>

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Primitives;
+
+public class PdfArrayTests
+{
+    public static IEnumerable<object[]> PdfArray_ParameterizedContructor_TestCases()
+    {
+        yield return new object[] { new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfName("SomeName") } };
+    }
+
+    [Theory(DisplayName = "Create an instance using parametrized constructor and check the Value property")]
+    [MemberData(nameof(PdfArray_ParameterizedContructor_TestCases))]
+    public void PdfArray_ParameterizedContructor_CheckValue(IEnumerable<IPdfObject> inputValue)
+    {
+        // Arrange
+        PdfArray pdfArray = PdfArray.CreateRange(inputValue); // Use the CreateRange static method to initialize an PdfArray instance
+
+        // Act
+
+        // Assert
+        Assert.Equal(inputValue, pdfArray.Value); // Checks if reference is equal
+    }
+
+    public static IEnumerable<object[]> PdfArray_Length_TestCases()
+    {
+        yield return new object[] { new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") }, 34 };
+        yield return new object[] { new List<IPdfObject>() { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, 13 };
+    }
+
+    [Theory(DisplayName = "Check the length of the PDF name primitive")]
+    [MemberData(nameof(PdfArray_Length_TestCases))]
+    public void PdfArray_Length_CheckValue(IEnumerable<IPdfObject> inputValue, int expectedLength)
+    {
+        // Arrange
+        PdfArray pdfArray = inputValue.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        int actualLength = pdfArray.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfArray_Equals_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfArray pdfArray1 = new PdfName("Name1").ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        bool actualResult = pdfArray1.Equals(null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method if the argument is null")]
+    public void PdfArray_Equals2_NullArgument_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfArray pdfArray1 = PdfArray.Create(new PdfString("901FA", isHexString: true)); // Use the Create static method to initialize an PdfArray instance
+
+        // Act
+        bool actualResult = pdfArray1.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method that has the same reference as a value")]
+    public void PdfArray_Equals_SameReference_ShouldReturnTrue()
+    {
+        // Arrange
+        IReadOnlyCollection<IPdfObject> objects1 = new List<IPdfObject> { new PdfInteger(-65), new PdfName("#ABC") };
+        PdfArray pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray pdfArray2 = pdfArray1; // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        bool actualResult = pdfArray1.Equals((object)pdfArray2);
+
+        // Assert
+        Assert.True(actualResult);
+    }
+
+    [Fact(DisplayName = "Check Equals method that has different references as values")]
+    public void PdfArray_Equals_DifferrentReferences_ShouldReturnFalse()
+    {
+        // Arrange
+        IReadOnlyCollection<IPdfObject> objects1 = new List<IPdfObject> { new PdfInteger(-65), new PdfName("#ABC") };
+        PdfArray pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray pdfArray2 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        bool actualResult = pdfArray1.Equals((object)pdfArray2);
+
+        // Assert
+        Assert.False(actualResult);
+    }
+
+    public static IEnumerable<object[]> PdfArray_Bytes_TestCases()
+    {
+        yield return new object[] { new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") }, new byte[] { 91, 53, 52, 57, 32, 51, 46, 49, 52, 32, 102, 97, 108, 115, 101, 32, 40, 82, 97, 108, 112, 104, 41, 32, 47, 83, 111, 109, 101, 78, 97, 109, 101, 93 } };
+        yield return new object[] { new List<IPdfObject>() { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, new byte[] { 91, 116, 114, 117, 101, 32, 91, 110, 117, 108, 108, 93, 93 } };
+    }
+
+    [Theory(DisplayName = "Check if Bytes property returns valid data")]
+    [MemberData(nameof(PdfArray_Bytes_TestCases))]
+    public void PdfArray_Bytes_CheckValidity(IReadOnlyCollection<IPdfObject> value1, byte[] expectedBytes)
+    {
+        // Arrange
+        PdfArray pdfArray1 = value1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        byte[] actualBytes = pdfArray1.Bytes;
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    public static IEnumerable<object[]> PdfArray_GetHashCode_TestCases()
+    {
+        yield return new object[] { new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") }};
+        yield return new object[] { new List<IPdfObject>() { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) } };
+    }
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [MemberData(nameof(PdfArray_GetHashCode_TestCases))]
+    public void PdfArray_GetHashCode_CheckValidity(IReadOnlyCollection<IPdfObject> value1)
+    {
+        // Arrange
+        PdfArray pdfArray1 = new PdfArray(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value1.GetHashCode());
+
+        // Act
+        int actualHashCode = pdfArray1.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Fact(DisplayName = "Compare the hash codes of two array objects.")]
+    public void PdfArray_GetHashCode_CompareHashes_ShouldBeEqual()
+    {
+        // Arrange
+        List<IPdfObject> value1 = new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") };
+        PdfArray pdfArray1 = new PdfArray(value1);
+        PdfArray pdfArray2 = new PdfArray(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value1.GetHashCode());
+
+        // Act
+        int actualHashCode1 = pdfArray1.GetHashCode();
+        int actualHashCode2 = pdfArray2.GetHashCode();
+        bool areHashCodeEquals = actualHashCode1 == actualHashCode2;
+
+        // Assert
+        Assert.True(areHashCodeEquals);
+        Assert.Equal(expectedHashCode, actualHashCode1);
+        Assert.Equal(expectedHashCode, actualHashCode2);
+    }
+
+    [Fact(DisplayName = "Compare the hash codes of two array objects.")]
+    public void PdfArray_GetHashCode_CompareHashes_ShouldNotBeEqual()
+    {
+        // Arrange
+        List<IPdfObject> value1 = new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") };
+        List<IPdfObject> value2 = new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") };
+        PdfArray pdfArray1 = new PdfArray(value1);
+        PdfArray pdfArray2 = new PdfArray(value2);
+
+        // Act
+        int actualHashCode1 = pdfArray1.GetHashCode();
+        int actualHashCode2 = pdfArray2.GetHashCode();
+        bool areHashCodeEquals = actualHashCode1 == actualHashCode2;
+
+        // Assert
+        Assert.False(areHashCodeEquals);
+    }
+
+    [Fact(DisplayName = "Check the Value property.")]
+    public void PdfArray_Value_Count_ShouldReturn1()
+    {
+        // Arrange
+        PdfArray pdfArray1 = PdfArray.Create(new PdfInteger(549));
+
+        // Act
+        int actualValueCount = pdfArray1.Value.Count;
+
+        // Assert
+        Assert.Equal(1, actualValueCount);
+    }
+
+    public static IEnumerable<object[]> PdfArray_Content_TestCases()
+    {
+        yield return new object[] { new List<IPdfObject>() { new PdfInteger(549), new PdfReal(3.14f), new PdfBoolean(), new PdfString("Ralph"), new PdfName("SomeName") }, "[549 3.14 false (Ralph) /SomeName]" };
+        yield return new object[] { new List<IPdfObject>() { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, "[true [null]]" };
+        yield return new object[] { new List<IPdfObject>() { }, "[]" };
+    }
+
+    [Theory(DisplayName = "Check the Content property.")]
+    [MemberData(nameof(PdfArray_Content_TestCases))]
+    public void PdfArray_Content_Check(IReadOnlyCollection<IPdfObject> inputValues, string expectedContentValue)
+    {
+        // Arrange
+        PdfArray pdfArray1 = inputValues.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+
+        // Act
+        string actualContentValue = pdfArray1.Content;
+        string actualContentValue2 = pdfArray1.Content;
+
+        // Assert
+        Assert.Equal(expectedContentValue, actualContentValue);
+        Assert.Equal(actualContentValue.GetHashCode(), actualContentValue2.GetHashCode());
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
@@ -189,16 +189,16 @@ public class PdfBooleanTests
         Assert.Equal(expectedValue, actualValue);
     }
 
-    [Theory(DisplayName = "Check ToString method for equality")]
+    [Theory(DisplayName = "Check Content property for equality")]
     [InlineData(false, "false")]
     [InlineData(true, "true")]
-    public void PdfBoolean_ToString_CheckEquality(bool value1, string expectedPdfBooleanStringValue)
+    public void PdfBoolean_Content_CheckEquality(bool value1, string expectedPdfBooleanStringValue)
     {
         // Arrange
         PdfBoolean pdfBoolean1 = value1; // Use an implicit conversion from bool to PdfBoolean
 
         // Act
-        string actualPdfBooleanStringValue = pdfBoolean1.ToString();
+        string actualPdfBooleanStringValue = pdfBoolean1.Content;
 
         // Assert
         Assert.Equal(expectedPdfBooleanStringValue, actualPdfBooleanStringValue);

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
@@ -237,19 +237,19 @@ public class PdfIntegerTests
         Assert.Throws<ArgumentException>(actualValueDelegate);
     }
 
-    [Theory(DisplayName = "Check ToString method for equality")]
+    [Theory(DisplayName = "Check Content property for equality")]
     [InlineData(123, "123")]
     [InlineData(43445, "43445")]
     [InlineData(+17, "17")] // Plus sign is automatically removed by C#.
     [InlineData(-98, "-98")] // Minus sign + two digits.
     [InlineData(0, "0")]
-    public void PdfInteger_ToString_CheckEquality(int value1, string expectedPdfIntegerStringValue)
+    public void PdfInteger_Content_CheckEquality(int value1, string expectedPdfIntegerStringValue)
     {
         // Arrange
         PdfInteger pdfInteger1 = value1; // Use an implicit conversion from int to PdfInteger
 
         // Act
-        string actualPdfIntegerStringValue = pdfInteger1.ToString();
+        string actualPdfIntegerStringValue = pdfInteger1.Content;
 
         // Assert
         Assert.Equal(expectedPdfIntegerStringValue, actualPdfIntegerStringValue);

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
@@ -29,18 +29,33 @@ public class PdfNameTests
         Assert.Equal(expectedValue, pdfName.Value);
     }
 
+    [Theory(DisplayName = "Constructor should throw and exception when the value is null or contain whitespaces")]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void PdfName_ParameterizedContructor_NullOrWhitespace_ShouldThrowArgumentNullException(string inputValue)
+    {
+        // Arrange
+
+        // Act
+        Action pdfNameDelegate = () => new PdfName(inputValue);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(pdfNameDelegate);
+    }
+
     [Theory(DisplayName = "Check the length of the PDF name primitive")]
-    [InlineData("Name1", 5)]
-    [InlineData("ASomewhatLongerName", 19)]
-    [InlineData("A;Name_With-Various***Characters?", 33)]
-    [InlineData("1.2", 3)]
-    [InlineData("$$", 2)]
-    [InlineData("@pattern", 8)]
-    [InlineData(".notdef", 7)]
-    [InlineData("Lime Green", 12)]
-    [InlineData("paired()parentheses", 23)]
-    [InlineData("The_Key_of_F#_Minor", 21)]
-    [InlineData("/NameWithSolidus", 18)]
+    [InlineData("Name1", 6)] // Solidus character + Name1
+    [InlineData("ASomewhatLongerName", 20)]
+    [InlineData("A;Name_With-Various***Characters?", 34)]
+    [InlineData("1.2", 4)]
+    [InlineData("$$", 3)]
+    [InlineData("@pattern", 9)]
+    [InlineData(".notdef", 8)]
+    [InlineData("Lime Green", 13)]
+    [InlineData("paired()parentheses", 24)]
+    [InlineData("The_Key_of_F#_Minor", 22)]
+    [InlineData("/NameWithSolidus", 19)]
     public void PdfName_Length_CheckValue(string value, int expectedLength)
     {
         // Arrange
@@ -97,17 +112,17 @@ public class PdfNameTests
     }
 
     [Theory(DisplayName = "Check if Bytes property returns valid data")]
-    [InlineData("Name1", new byte[] { 78, 97, 109, 101, 49 })]
-    [InlineData("ASomewhatLongerName", new byte[] { 65, 83, 111, 109, 101, 119, 104, 97, 116, 76, 111, 110, 103, 101, 114, 78, 97, 109, 101 })]
-    [InlineData("A;Name_With-Various***Characters?", new byte[] { 65, 59, 78, 97, 109, 101, 95, 87, 105, 116, 104, 45, 86, 97, 114, 105, 111, 117, 115, 42, 42, 42, 67, 104, 97, 114, 97, 99, 116, 101, 114, 115, 63 })]
-    [InlineData("1.2", new byte[] { 49, 46, 50 })]
-    [InlineData("$$", new byte[] { 36, 36 })]
-    [InlineData("@pattern", new byte[] { 64, 112, 97, 116, 116, 101, 114, 110 })]
-    [InlineData(".notdef", new byte[] { 46, 110, 111, 116, 100, 101, 102 })]
-    [InlineData("Lime Green", new byte[] { 76, 105, 109, 101, 35, 50, 48, 71, 114, 101, 101, 110 })]
-    [InlineData("paired()parentheses", new byte[] { 112, 97, 105, 114, 101, 100, 35, 50, 56, 35, 50, 57, 112, 97, 114, 101, 110, 116, 104, 101, 115, 101, 115 })]
-    [InlineData("The_Key_of_F#_Minor", new byte[] { 84, 104, 101, 95, 75, 101, 121, 95, 111, 102, 95, 70, 35, 50, 51, 95, 77, 105, 110, 111, 114 })]
-    [InlineData("/NameWithSolidus", new byte[] { 35, 50, 70, 78, 97, 109, 101, 87, 105, 116, 104, 83, 111, 108, 105, 100, 117, 115 })]
+    [InlineData("Name1", new byte[] { 47, 78, 97, 109, 101, 49 })]
+    [InlineData("ASomewhatLongerName", new byte[] { 47, 65, 83, 111, 109, 101, 119, 104, 97, 116, 76, 111, 110, 103, 101, 114, 78, 97, 109, 101 })]
+    [InlineData("A;Name_With-Various***Characters?", new byte[] { 47, 65, 59, 78, 97, 109, 101, 95, 87, 105, 116, 104, 45, 86, 97, 114, 105, 111, 117, 115, 42, 42, 42, 67, 104, 97, 114, 97, 99, 116, 101, 114, 115, 63 })]
+    [InlineData("1.2", new byte[] { 47, 49, 46, 50 })]
+    [InlineData("$$", new byte[] { 47, 36, 36 })]
+    [InlineData("@pattern", new byte[] { 47, 64, 112, 97, 116, 116, 101, 114, 110 })]
+    [InlineData(".notdef", new byte[] { 47, 46, 110, 111, 116, 100, 101, 102 })]
+    [InlineData("Lime Green", new byte[] { 47, 76, 105, 109, 101, 35, 50, 48, 71, 114, 101, 101, 110 })]
+    [InlineData("paired()parentheses", new byte[] { 47, 112, 97, 105, 114, 101, 100, 35, 50, 56, 35, 50, 57, 112, 97, 114, 101, 110, 116, 104, 101, 115, 101, 115 })]
+    [InlineData("The_Key_of_F#_Minor", new byte[] { 47, 84, 104, 101, 95, 75, 101, 121, 95, 111, 102, 95, 70, 35, 50, 51, 95, 77, 105, 110, 111, 114 })]
+    [InlineData("/NameWithSolidus", new byte[] { 47, 35, 50, 70, 78, 97, 109, 101, 87, 105, 116, 104, 83, 111, 108, 105, 100, 117, 115 })]
     public void PdfName_Bytes_CheckValidity(string value1, byte[] expectedBytes)
     {
         // Arrange
@@ -223,47 +238,47 @@ public class PdfNameTests
         Assert.Equal(expectedValue, actualValue);
     }
 
-    [Theory(DisplayName = "Check ToString method for equality")]
-    [InlineData("Name1", "Name1")]
-    [InlineData("ASomewhatLongerName", "ASomewhatLongerName")]
-    [InlineData("A;Name_With-Various***Characters?", "A;Name_With-Various***Characters?")]
-    [InlineData("1.2", "1.2")]
-    [InlineData("$$", "$$")]
-    [InlineData("@pattern", "@pattern")]
-    [InlineData(".notdef", ".notdef")]
-    [InlineData("Lime Green", "Lime#20Green")]
-    [InlineData("paired()parentheses", "paired#28#29parentheses")]
-    [InlineData("The_Key_of_F#_Minor", "The_Key_of_F#23_Minor")]
-    [InlineData("/NameWithSolidus", "#2FNameWithSolidus")]
-    [InlineData("NameWith%Percent", "NameWith#25Percent")]
-    [InlineData("NameWith>GreaterThanChar", "NameWith#3EGreaterThanChar")]
-    [InlineData("NameWith<LessThanChar", "NameWith#3CLessThanChar")]
-    [InlineData("NameWith[LeftSquareBracket", "NameWith#5BLeftSquareBracket")]
-    [InlineData("NameWith]RightSquareBracket", "NameWith#5DRightSquareBracket")]
-    [InlineData("NameWith{LeftCurlyBracket", "NameWith#7BLeftCurlyBracket")]
-    [InlineData("NameWith}RightCurlyBracket", "NameWith#7DRightCurlyBracket")]
-    [InlineData("NameWith\x007FDeleteChar", "NameWith#7FDeleteChar")]
-    public void PdfName_ToString_CheckEquality(string value1, string expectedPdfNameStringValue)
+    [Theory(DisplayName = "Check Content property for equality")]
+    [InlineData("Name1", "/Name1")]
+    [InlineData("ASomewhatLongerName", "/ASomewhatLongerName")]
+    [InlineData("A;Name_With-Various***Characters?", "/A;Name_With-Various***Characters?")]
+    [InlineData("1.2", "/1.2")]
+    [InlineData("$$", "/$$")]
+    [InlineData("@pattern", "/@pattern")]
+    [InlineData(".notdef", "/.notdef")]
+    [InlineData("Lime Green", "/Lime#20Green")]
+    [InlineData("paired()parentheses", "/paired#28#29parentheses")]
+    [InlineData("The_Key_of_F#_Minor", "/The_Key_of_F#23_Minor")]
+    [InlineData("/NameWithSolidus", "/#2FNameWithSolidus")]
+    [InlineData("NameWith%Percent", "/NameWith#25Percent")]
+    [InlineData("NameWith>GreaterThanChar", "/NameWith#3EGreaterThanChar")]
+    [InlineData("NameWith<LessThanChar", "/NameWith#3CLessThanChar")]
+    [InlineData("NameWith[LeftSquareBracket", "/NameWith#5BLeftSquareBracket")]
+    [InlineData("NameWith]RightSquareBracket", "/NameWith#5DRightSquareBracket")]
+    [InlineData("NameWith{LeftCurlyBracket", "/NameWith#7BLeftCurlyBracket")]
+    [InlineData("NameWith}RightCurlyBracket", "/NameWith#7DRightCurlyBracket")]
+    [InlineData("NameWith\x007FDeleteChar", "/NameWith#7FDeleteChar")]
+    public void PdfName_Content_CheckEquality(string value1, string expectedPdfNameStringValue)
     {
         // Arrange
         PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
 
         // Act
-        string actualPdfNameStringValue = pdfName1.ToString();
+        string actualPdfNameStringValue = pdfName1.Content;
 
         // Assert
         Assert.Equal(expectedPdfNameStringValue, actualPdfNameStringValue);
     }
 
-    [Fact(DisplayName = "Check ToString method for multiple accessing")]
-    public void PdfName_ToString_CheckMultipleAccessing()
+    [Fact(DisplayName = "Check Content property for multiple accessing")]
+    public void PdfName_Content_CheckMultipleAccessing()
     {
         // Arrange
         PdfName pdfName1 = "CustomName"; // Use an implicit conversion from string to PdfName
 
         // Act
-        string firstString = pdfName1.ToString();
-        string secondString = pdfName1.ToString();
+        string firstString = pdfName1.Content;
+        string secondString = pdfName1.Content;
 
         // Assert
         Assert.Equal(firstString, secondString);

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
@@ -90,15 +90,15 @@ public class PdfNullTests
         Assert.True(areHashCodeEquals);
     }
 
-    [Fact(DisplayName = "Check ToString method for equality")]
-    public void PdfNull_ToString_CheckEquality()
+    [Fact(DisplayName = "Check Content property for equality")]
+    public void PdfNull_Content_CheckEquality()
     {
         // Arrange
         PdfNull pdfNull1 = new PdfNull();
         const string expectedStringValue = "null";
 
         // Act
-        string actualPdfNullStringValue = pdfNull1.ToString();
+        string actualPdfNullStringValue = pdfNull1.Content;
 
         // Assert
         Assert.Equal(expectedStringValue, actualPdfNullStringValue);

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
@@ -229,19 +229,19 @@ public class PdfRealTests
         Assert.Throws<ArgumentException>(actualValueDelegate);
     }
 
-    [Theory(DisplayName = "Check ToString method for equality")]
+    [Theory(DisplayName = "Check Content property for equality")]
     [InlineData(34.5, "34.5")]
     [InlineData(-3.62, "-3.62")]
     [InlineData(+123.6, "123.6")] // Plus sign is automatically removed by C#.
     [InlineData(4.0, "4")]
     [InlineData(-.002, "-0.002")]
-    public void PdfReal_ToString_CheckEquality(float value1, string expectedPdfRealStringValue)
+    public void PdfReal_Content_CheckEquality(float value1, string expectedPdfRealStringValue)
     {
         // Arrange
         PdfReal pdfReal1 = value1; // Use an implicit conversion from float to PdfReal
 
         // Act
-        string actualPdfRealStringValue = pdfReal1.ToString();
+        string actualPdfRealStringValue = pdfReal1.Content;
 
         // Assert
         Assert.Equal(expectedPdfRealStringValue, actualPdfRealStringValue);

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
@@ -225,7 +225,7 @@ public class PdfStringTests
         Assert.Equal(expectedValue, actualValue);
     }
 
-    [Theory(DisplayName = "Check ToString method for equality")]
+    [Theory(DisplayName = "Check Content property for equality")]
     [InlineData("This is a string", "(This is a string)", false)]
     [InlineData("Strings may contain newlines\r\nand such.", "(Strings may contain newlines\r\nand such.)", false)]
     [InlineData("Strings may contain balanced parentheses ( ) and\r\nspecial characters (*!&}^% and so on).", "(Strings may contain balanced parentheses ( ) and\r\nspecial characters (*!&}^% and so on).)", false)]
@@ -241,27 +241,27 @@ public class PdfStringTests
     [InlineData("\t90\n1F\rA3\r\n\f", "<\t90\n1F\rA3\r\n\f>", true)] // White-spaces should be ignored in hex string
     [InlineData("901FA", "<901FA>", true)] // If the last digit is missing, the last digit is considered 0, i.e. 901FA0
     [InlineData("901fa", "<901fa>", true)] // If the last digit is missing, the last digit is considered 0, i.e. 901fa0
-    public void PdfString_ToString_CheckEquality(string value1, string expectedPdfStringStringValue, bool isHexValue)
+    public void PdfString_Content_CheckEquality(string value1, string expectedPdfStringStringValue, bool isHexValue)
     {
         // Arrange
         PdfString pdfString1 = new PdfString(value1, isHexValue);
 
         // Act
-        string actualPdfStringStringValue = pdfString1.ToString();
+        string actualPdfStringStringValue = pdfString1.Content;
 
         // Assert
         Assert.Equal(expectedPdfStringStringValue, actualPdfStringStringValue);
     }
 
-    [Fact(DisplayName = "Check ToString method for multiple accessing")]
-    public void PdfString_ToString_CheckMultipleAccessing()
+    [Fact(DisplayName = "Check Content property for multiple accessing")]
+    public void PdfString_Content_CheckMultipleAccessing()
     {
         // Arrange
         PdfString pdfString1 = "CustomString"; // Use an implicit conversion from string to PdfString
 
         // Act
-        string firstString = pdfString1.ToString();
-        string secondString = pdfString1.ToString();
+        string firstString = pdfString1.Content;
+        string secondString = pdfString1.Content;
 
         // Assert
         Assert.Equal(firstString, secondString);


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.3.6`, the Array object is a one-dimensional collection of different PDF objects arranged sequentially. An array may have zero elements.

PDF directly supports only one-dimensional arrays. Arrays of higher dimensions can be constructed by using arrays as elements of arrays, nested to any depth. 

Example:

```
[549 3.14 false (Ralph) /SomeName]
```

### Acceptance criteria

1. Create a `PdfArray` class.
2. Implement the `IPdfObject`, `IEquatable` interfaces.
3. Override the `GetHashCode` method.
4. Cover the primitive implementation with the unit, and mutation tests.