### PR TITLE
feat(file-structure): added xref entry object

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.0.4",
+      "version": "5.1.15",
       "commands": [
         "reportgenerator"
       ]

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+  <!-- Source: https://www.meziantou.net/declaring-internalsvisibleto-in-the-csproj.htm -->
+  <Target Name="AddInternalsVisibleTo" BeforeTargets="BeforeCompile">
+    <ItemGroup Condition="@(InternalsVisibleToSuffix->Count()) == 0 AND @(InternalsVisibleTo->Count()) == 0">
+      <InternalsVisibleToSuffix Include=".Tests"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(InternalsVisibleTo->Count())' &gt; 0">
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>%(InternalsVisibleTo.Identity)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup Condition="@(InternalsVisibleToSuffix->Count()) &gt; 0">
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>$(AssemblyName)%(InternalsVisibleToSuffix.Identity)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Off.Net.sln
+++ b/Off.Net.sln
@@ -11,8 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		.netconfig = .netconfig
-		.config\dotnet-tools.json = .config\dotnet-tools.json
 		README.md = README.md
+		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{9AD1AB50-CB0F-43D9-B721-DE1572FC6875}"

--- a/src/Off.Net.Pdf.Core/Extensions/GuardClauses.cs
+++ b/src/Off.Net.Pdf.Core/Extensions/GuardClauses.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Off.Net.Pdf.Core.Extensions;
+
+internal static class GuardClauses
+{
+    public static void NotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string? paramName = null)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+    }
+
+    public static T CheckConstraints<T>(this T value, Func<T, bool> checkFunc, string exceptionMessage, [CallerArgumentExpression("value")] string? paramName = null)
+    {
+        if (!checkFunc(value))
+        {
+            throw new ArgumentOutOfRangeException(paramName, exceptionMessage);
+        }
+        return value;
+    }
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefEntry.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefEntry.cs
@@ -1,0 +1,91 @@
+﻿using System.Text;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.FileStructure;
+
+public enum XRefEntryType
+{
+    InUse,
+    Free,
+}
+
+public sealed class XRefEntry : IPdfObject, IEquatable<XRefEntry>
+{
+    #region Fields
+
+    private readonly int _hashCode;
+    private readonly Lazy<string> _literalValue;
+    private readonly Lazy<byte[]> _bytes;
+
+    #endregion
+
+    #region Constructors
+
+    public XRefEntry(long byteOffset, int generationNumber, XRefEntryType entryType)
+    {
+        ByteOffset = byteOffset
+            .CheckConstraints(num => num >= 0, Resource.XRefEntry_ByteOffsetMustBePositive)
+            .CheckConstraints(num => num <= 9999999999, Resource.XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue);
+
+        GenerationNumber = generationNumber
+            .CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive)
+            .CheckConstraints(num => num <= 65535, Resource.PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue);
+
+        EntryType = entryType;
+
+        _hashCode = HashCode.Combine(nameof(XRefEntry).GetHashCode(), byteOffset.GetHashCode(), generationNumber.GetHashCode());
+        _literalValue = new Lazy<string>(GenerateContent);
+        _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int Length => Content.Length;
+
+    public ReadOnlyMemory<byte> Bytes => _bytes.Value;
+
+    public long ByteOffset { get; }
+
+    public int GenerationNumber { get; }
+
+    public XRefEntryType EntryType { get; }
+
+    public string Content => _literalValue.Value;
+
+    #endregion
+
+    #region Public Methods
+
+    public override int GetHashCode()
+    {
+        return _hashCode;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as XRefEntry);
+    }
+
+    public bool Equals(XRefEntry? other)
+    {
+        return other is not null &&
+               ByteOffset == other.ByteOffset &&
+               GenerationNumber == other.GenerationNumber &&
+               EntryType == other.EntryType;
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private string GenerateContent()
+    {
+        char literalEntryType = EntryType == XRefEntryType.Free ? 'f' : 'n';
+        return $"{ByteOffset:D10} {GenerationNumber:D5} {literalEntryType} \n";
+    }
+
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefSection.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefSection.cs
@@ -1,0 +1,6 @@
+﻿namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class XRefSection
+{
+
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefTable.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefTable.cs
@@ -1,0 +1,6 @@
+﻿namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class XRefTable
+{
+
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XrefSubSection.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XrefSubSection.cs
@@ -1,0 +1,6 @@
+﻿namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class XrefSubSection
+{
+
+}

--- a/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
+++ b/src/Off.Net.Pdf.Core/Interfaces/IPdfObject.cs
@@ -10,7 +10,7 @@ public interface IPdfObject
     /// <summary>
     ///     Gets the bytes array representation of the Pdf object.
     /// </summary>
-    byte[] Bytes { get; }
+    ReadOnlyMemory<byte> Bytes { get; }
 
     string Content { get; }
 }

--- a/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
@@ -25,7 +25,7 @@ public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEqu
 
     public IReadOnlyCollection<IPdfObject> Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfBoolean.cs
@@ -23,7 +23,7 @@ public struct PdfBoolean : IPdfObject<bool>, IEquatable<PdfBoolean>
 
     public bool Value { get; }
 
-    public byte[] Bytes { get; }
+    public ReadOnlyMemory<byte> Bytes { get; }
 
     public string Content { get; }
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
@@ -31,7 +31,7 @@ public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdf
 
     public IReadOnlyDictionary<PdfName, IPdfObject> Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
 

--- a/src/Off.Net.Pdf.Core/Primitives/PdfIndirect.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfIndirect.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Off.Net.Pdf.Core.Extensions;
 using Off.Net.Pdf.Core.Interfaces;
 
 namespace Off.Net.Pdf.Core.Primitives;
@@ -17,18 +18,13 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
 
     public PdfIndirect(IPdfObject pdfObject, int objectNumber, int generationNumber = 0)
     {
-        if (objectNumber < 0)
-        {
-            throw new ArgumentException(Resource.PdfIndirect_ObjectNumberMustBePositive, nameof(objectNumber));
-        }
+        ObjectNumber = objectNumber
+            .CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive);
 
-        if (generationNumber < 0)
-        {
-            throw new ArgumentException(Resource.PdfIndirect_GenerationNumberMustBePositive, nameof(objectNumber));
-        }
+        GenerationNumber = generationNumber
+            .CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive)
+            .CheckConstraints(num => num <= 65535, Resource.PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue);
 
-        ObjectNumber = objectNumber;
-        GenerationNumber = generationNumber;
         Value = pdfObject;
         _hashCode = HashCode.Combine(nameof(PdfIndirect).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
         _bytes = null;
@@ -47,7 +43,7 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
 
     public int Length => Content.Length;
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
 

--- a/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfInteger.cs
@@ -30,7 +30,7 @@ public struct PdfInteger : IPdfObject<int>, IEquatable<PdfInteger>, IComparable,
 
     public int Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
@@ -42,7 +42,7 @@ public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
 
     public string Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfNull.cs
@@ -8,13 +8,13 @@ public struct PdfNull : IPdfObject
     #region Fields
     private const string LiteralValue = "null";
     private static readonly int HashCode = System.HashCode.Combine(nameof(PdfNull).GetHashCode(), LiteralValue.GetHashCode());
-    private static readonly byte[] BytesArray = Encoding.ASCII.GetBytes(LiteralValue);
+    private static readonly ReadOnlyMemory<byte> BytesArray = Encoding.ASCII.GetBytes(LiteralValue);
     #endregion
 
     #region Properties
     public int Length => 4;
 
-    public byte[] Bytes => BytesArray;
+    public ReadOnlyMemory<byte> Bytes => BytesArray;
 
     public string Content => LiteralValue;
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfReal.cs
@@ -37,7 +37,7 @@ public struct PdfReal : IPdfObject<float>, IEquatable<PdfReal>, IComparable, ICo
 
     public float Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfStream.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfStream.cs
@@ -40,7 +40,7 @@ public sealed class PdfStream : IPdfObject<ReadOnlyMemory<char>>, IEquatable<Pdf
 
     public ReadOnlyMemory<char> Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
 

--- a/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
@@ -32,7 +32,7 @@ public sealed class PdfString : IPdfObject<string>, IEquatable<PdfString>
 
     public string Value { get; }
 
-    public byte[] Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
+    public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
     #endregion

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -60,11 +60,20 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The generation number of the PDF indirect type must be positive.
+        ///   Looks up a localized string similar to The generation number must be positive.
         /// </summary>
         internal static string PdfIndirect_GenerationNumberMustBePositive {
             get {
                 return ResourceManager.GetString("PdfIndirect_GenerationNumberMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The generation number must not exceed 65535.
+        /// </summary>
+        internal static string PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue {
+            get {
+                return ResourceManager.GetString("PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue", resourceCulture);
             }
         }
         
@@ -137,6 +146,24 @@ namespace Off.Net.Pdf.Core {
         internal static string PdfString_MustNotBeEmpty {
             get {
                 return ResourceManager.GetString("PdfString_MustNotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The byte offset of the XRef entry must be positive.
+        /// </summary>
+        internal static string XRefEntry_ByteOffsetMustBePositive {
+            get {
+                return ResourceManager.GetString("XRefEntry_ByteOffsetMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The byte offset must not exceed 9999999999.
+        /// </summary>
+        internal static string XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue {
+            get {
+                return ResourceManager.GetString("XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue", resourceCulture);
             }
         }
     }

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -147,6 +147,15 @@
     <value>The object number of the PDF indirect type must be positive</value>
   </data>
   <data name="PdfIndirect_GenerationNumberMustBePositive" xml:space="preserve">
-    <value>The generation number of the PDF indirect type must be positive</value>
+    <value>The generation number must be positive</value>
+  </data>
+  <data name="PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue" xml:space="preserve">
+    <value>The generation number must not exceed 65535</value>
+  </data>
+  <data name="XRefEntry_ByteOffsetMustBePositive" xml:space="preserve">
+    <value>The byte offset of the XRef entry must be positive</value>
+  </data>
+  <data name="XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue" xml:space="preserve">
+    <value>The byte offset must not exceed 9999999999</value>
   </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
@@ -1,0 +1,249 @@
+﻿using System;
+using System.Diagnostics;
+using Off.Net.Pdf.Core.FileStructure;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.FileStructure;
+
+public class XRefEntryTests
+{
+    [Theory(DisplayName = $"Constructor with negative {nameof(XRefEntry.ByteOffset)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1)]
+    [InlineData(-15)]
+    [InlineData(-23)]
+    public void XRefEntry_NegativeByteOffset_ShouldThrowException(int byteOffset)
+    {
+        // Arrange
+
+        // Act
+        XRefEntry XRefEntryFunction() => new(byteOffset, 0, XRefEntryType.InUse);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefEntryFunction);
+        Assert.StartsWith(Resource.XRefEntry_ByteOffsetMustBePositive, exception.Message);
+    }
+
+    [Theory(DisplayName = $"Constructor with overflowed {nameof(XRefEntry.ByteOffset)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(99999999999)]
+    [InlineData(19999999999)]
+    [InlineData(10000000000)]
+    [InlineData(long.MaxValue)]
+    public void XRefEntry_OverflowByteOffset_ShouldThrowException(long byteOffset)
+    {
+        // Arrange
+
+        // Act
+        XRefEntry XRefEntryFunction() => new(byteOffset, 0, XRefEntryType.InUse);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefEntryFunction);
+        Assert.StartsWith(Resource.XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue, exception.Message);
+    }
+
+    [Theory(DisplayName = $"Constructor with negative {nameof(XRefEntry.GenerationNumber)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1)]
+    [InlineData(-15)]
+    [InlineData(-23)]
+    public void XRefEntry_NegativeGenerationNumber_ShouldThrowException(int generationNumber)
+    {
+        // Arrange
+
+        // Act
+        XRefEntry XRefEntryFunction() => new(0, generationNumber, XRefEntryType.InUse);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefEntryFunction);
+        Assert.StartsWith(Resource.PdfIndirect_ObjectNumberMustBePositive, exception.Message);
+    }
+
+    [Theory(DisplayName = $"Constructor with overflowed {nameof(XRefEntry.GenerationNumber)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(100000)]
+    [InlineData(ushort.MaxValue + 1)]
+    [InlineData(int.MaxValue)]
+    public void XRefEntry_OverflowGenerationNumber_ShouldThrowException(int generationNumber)
+    {
+        // Arrange
+
+        // Act
+        XRefEntry XRefEntryFunction() => new(0, generationNumber, XRefEntryType.InUse);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefEntryFunction);
+        Assert.StartsWith(Resource.PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue, exception.Message);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.Content)} property should return a valid value")]
+    [InlineData(0, 0, true, "0000000000 00000 n \n")]
+    [InlineData(52, 123, false, "0000000052 00123 f \n")]
+    [InlineData(4567, 1234, false, "0000004567 01234 f \n")]
+    [InlineData(9999999999, 65535, true, "9999999999 65535 n \n")]
+    public void XRefEntry_Content_ShouldReturnValidValue(long byteOffset, int generationNumber, bool isInUse, string expectedContent)
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, isInUse ? XRefEntryType.InUse : XRefEntryType.Free);
+
+        // Act
+        string actualContent = xRefEntry.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.Length)} property should return always 20")]
+    [InlineData(0, 0, true)]
+    [InlineData(52, 123, false)]
+    [InlineData(4567, 1234, false)]
+    [InlineData(9999999999, 65535, true)]
+    public void XRefEntry_Length_ShouldReturn20(long byteOffset, int generationNumber, bool isInUse)
+    {
+        // Arrange
+        const int expectedLength = 20;
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, isInUse ? XRefEntryType.InUse : XRefEntryType.Free);
+
+        // Act
+        int actualLength = xRefEntry.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.ByteOffset)} property should return a valid value")]
+    [InlineData(0, 0, true)]
+    [InlineData(52, 123, false)]
+    [InlineData(4567, 1234, false)]
+    [InlineData(9999999999, 65535, true)]
+    public void XRefEntry_ByteOffset_ShouldReturnValidValue(long byteOffset, int generationNumber, bool isInUse)
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, isInUse ? XRefEntryType.InUse : XRefEntryType.Free);
+
+        // Act
+        long actualByteOffset = xRefEntry.ByteOffset;
+
+        // Assert
+        Assert.Equal(byteOffset, actualByteOffset);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.GenerationNumber)} property should return a valid value")]
+    [InlineData(0, 0, true)]
+    [InlineData(52, 123, false)]
+    [InlineData(4567, 1234, false)]
+    [InlineData(9999999999, 65535, true)]
+    public void XRefEntry_GenerationNumber_ShouldReturnValidValue(long byteOffset, int generationNumber, bool isInUse)
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, isInUse ? XRefEntryType.InUse : XRefEntryType.Free);
+
+        // Act
+        long actualGenerationNumber = xRefEntry.GenerationNumber;
+
+        // Assert
+        Assert.Equal(generationNumber, actualGenerationNumber);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.EntryType)} property should return a valid value")]
+    [InlineData(0, 0, true)]
+    [InlineData(52, 123, false)]
+    [InlineData(4567, 1234, false)]
+    [InlineData(9999999999, 65535, true)]
+    public void XRefEntry_EntryType_ShouldReturnValidValue(long byteOffset, int generationNumber, bool isInUse)
+    {
+        // Arrange
+        XRefEntryType xRefEntryType = isInUse ? XRefEntryType.InUse : XRefEntryType.Free;
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, xRefEntryType);
+
+        // Act
+        XRefEntryType actualXRefEntryType = xRefEntry.EntryType;
+
+        // Assert
+        Assert.Equal(xRefEntryType, actualXRefEntryType);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefEntry.Bytes)} property should return a valid value")]
+    [InlineData(0, 0, true, new byte[] { 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6e, 0x20, 0x0a })]
+    [InlineData(52, 123, false, new byte[] { 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x35, 0x32, 0x20, 0x30, 0x30, 0x31, 0x32, 0x33, 0x20, 0x66, 0x20, 0x0a })]
+    [InlineData(4567, 1234, false, new byte[] { 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, 0x35, 0x36, 0x37, 0x20, 0x30, 0x31, 0x32, 0x33, 0x34, 0x20, 0x66, 0x20, 0x0a })]
+    [InlineData(9999999999, 65535, true, new byte[] { 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x39, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x6e, 0x20, 0x0a })]
+    public void XRefEntry_Bytes_ShouldReturnValidValue(long byteOffset, int generationNumber, bool isInUse, byte[] expectedBytes)
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, isInUse ? XRefEntryType.InUse : XRefEntryType.Free);
+
+        // Act
+        byte[] actualBytes = xRefEntry.Bytes.ToArray();
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [InlineData(0, 0, true)]
+    [InlineData(52, 123, false)]
+    [InlineData(4567, 1234, false)]
+    [InlineData(9999999999, 65535, true)]
+    public void XRefEntry_GetHashCode_CheckValidity(long byteOffset, int generationNumber, bool isInUse)
+    {
+        // Arrange
+        XRefEntryType xRefEntryType = isInUse ? XRefEntryType.InUse : XRefEntryType.Free;
+        XRefEntry xRefEntry = new(byteOffset, generationNumber, xRefEntryType);
+        int expectedHashCode = HashCode.Combine(nameof(XRefEntry).GetHashCode(), byteOffset.GetHashCode(), generationNumber.GetHashCode());
+
+        // Act
+        int actualHashCode = xRefEntry.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Fact(DisplayName = $"{nameof(XRefEntry.Content)} property, accessed multiple times, should return the same reference")]
+    public void XRefEntry_Content_MultipleAccesses_ShouldReturnSameReference()
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(0, 0, XRefEntryType.InUse);
+
+        // Act
+        string actualContent1 = xRefEntry.Content;
+        string actualContent2 = xRefEntry.Content;
+
+        // Assert
+        Assert.True(ReferenceEquals(actualContent1, actualContent2));
+    }
+
+    [Theory(DisplayName = "Check if Equals returns a valid result")]
+    [InlineData(0, 0, 0, 0, true, true, true)]
+    [InlineData(52, 25, 123, 123, false, false, false)]
+    [InlineData(4567, 4567, 1234, 4321, false, false, false)]
+    [InlineData(9999999999, 9999999999, 65535, 65535, true, false, false)]
+    [InlineData(9999999999, 9999999999, 65535, 65535, true, true, true)]
+    public void XRefEntry_Equals_CheckValidity(long byteOffset1, long byteOffset2, int generationNumber1, int generationNumber2, bool isInUse1, bool isInUse2, bool expectedValue)
+    {
+        // Arrange
+        XRefEntryType xRefEntryType1 = isInUse1 ? XRefEntryType.InUse : XRefEntryType.Free;
+        XRefEntryType xRefEntryType2 = isInUse2 ? XRefEntryType.InUse : XRefEntryType.Free;
+        XRefEntry xRefEntry1 = new(byteOffset1, generationNumber1, xRefEntryType1);
+        XRefEntry xRefEntry2 = new(byteOffset2, generationNumber2, xRefEntryType2);
+
+        // Act
+        bool actualResult = xRefEntry1.Equals(xRefEntry2);
+
+        // Assert
+        Assert.Equal(expectedValue, actualResult);
+    }
+
+    [Fact(DisplayName = "Check if Equals method with null object returns always false")]
+    public void XRefEntry_EqualsNullObject_CheckValidity()
+    {
+        // Arrange
+        XRefEntry xRefEntry = new(0, 0, XRefEntryType.InUse);
+
+        // Act
+        bool actualResult1 = xRefEntry.Equals(null);
+
+        Debug.Assert(xRefEntry != null, nameof(xRefEntry) + " != null");
+        bool actualResult2 = xRefEntry.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult1);
+        Assert.False(actualResult2);
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj
+++ b/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
-    <PackageReference Include="xunit" Version="2.4.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
@@ -99,10 +99,10 @@ public class PdfArrayTests
         PdfArray pdfArray1 = value1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
-        byte[] actualBytes = pdfArray1.Bytes;
+        ReadOnlyMemory<byte> actualBytes = pdfArray1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
@@ -124,10 +124,10 @@ public class PdfBooleanTests
         PdfBoolean pdfBoolean1 = value1; // Use an implicit conversion from bool to PdfBoolean
 
         // Act
-        byte[] actualBytes = pdfBoolean1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfBoolean1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
@@ -99,10 +99,10 @@ public class PdfDictionaryTests
         PdfDictionary pdfDictionary1 = value1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
-        byte[] actualBytes = pdfDictionary1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfDictionary1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
@@ -153,10 +153,10 @@ public class PdfIndirectTests
         PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
-        byte[] actualBytes = pdfIndirect.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfIndirect.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Throw exception if object number is not positive")]
@@ -172,13 +172,14 @@ public class PdfIndirectTests
         Action pdfIndirectFunc = () => pdfString.ToPdfIndirect(objectNumber);
 
         // Assert
-        Assert.Throws<ArgumentException>(pdfIndirectFunc);
+        Assert.Throws<ArgumentOutOfRangeException>(pdfIndirectFunc);
     }
 
-    [Theory(DisplayName = "Throw exception if generation number is not positive")]
+    [Theory(DisplayName = "Throw exception if generation number is out of range")]
     [InlineData(-1)]
     [InlineData(-7)]
     [InlineData(-2465)]
+    [InlineData(65536)]
     public void PdfIndirect_Constructor_NegativeGenerationNumber_ShouldThrowException(int generationNumber)
     {
         // Arrange
@@ -188,6 +189,6 @@ public class PdfIndirectTests
         Action pdfIndirectFunc = () => pdfString.ToPdfIndirect(5, generationNumber);
 
         // Assert
-        Assert.Throws<ArgumentException>(pdfIndirectFunc);
+        Assert.Throws<ArgumentOutOfRangeException>(pdfIndirectFunc);
     }
 }

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
@@ -101,10 +101,10 @@ public class PdfIntegerTests
         PdfInteger pdfInteger1 = value1; // Use an implicit conversion from int to PdfInteger
 
         // Act
-        byte[] actualBytes = pdfInteger1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfInteger1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
@@ -130,10 +130,10 @@ public class PdfNameTests
         PdfName pdfName1 = value1; // Use an implicit conversion from string to PdfName
 
         // Act
-        byte[] actualBytes = pdfName1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfName1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
@@ -55,10 +55,10 @@ public class PdfNullTests
         PdfNull pdfNull1 = new();
 
         // Act
-        byte[] actualBytes = pdfNull1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfNull1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Fact(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
@@ -99,10 +99,10 @@ public class PdfRealTests
         PdfReal pdfReal1 = value1; // Use an implicit conversion from float to PdfReal
 
         // Act
-        byte[] actualBytes = pdfReal1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfReal1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
@@ -356,24 +356,10 @@ public class PdfStreamTests
         PdfStream pdfStream = new PdfString(pdfStringValue).ToPdfStream();
 
         // Act
-        byte[] actualBytes = pdfStream.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfStream.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
-    }
-
-    [Fact(DisplayName = $"{nameof(PdfStream.Bytes)} property, accessed multiple times, should return the same reference")]
-    public void PdfStream_Bytes_MultipleAccesses_ShouldReturnSameReference()
-    {
-        // Arrange
-        PdfStream pdfStream = new PdfString("Test").ToPdfStream();
-
-        // Act
-        byte[] actualStreamBytes1 = pdfStream.Bytes;
-        byte[] actualStreamBytes2 = pdfStream.Bytes;
-
-        // Assert
-        Assert.True(ReferenceEquals(actualStreamBytes1, actualStreamBytes2));
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Fact(DisplayName = "Check Equals method if the argument is null")]

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
@@ -117,10 +117,10 @@ public class PdfStringTests
         PdfString pdfString1 = value1; // Use an implicit conversion from string to PdfString
 
         // Act
-        byte[] actualBytes = pdfString1.Bytes;
+         ReadOnlyMemory<byte> actualBytes = pdfString1.Bytes;
 
         // Assert
-        Assert.Equal(expectedBytes, actualBytes);
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
     }
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.5.4`, the cross-reference entry contains information that permits random access to an indirect object.

Cross-Reference entry signature:

```
nnnnnnnnnn ggggg f eol
```

Cross-reference entry example:

```
0000000000 65535 f                  % Entry 1
```

### Acceptance criteria

1. Cross-Reference entry signature should be `20` bytes in length.
2. Cross-Reference entry should consist of the following parts separated by the `space` character:
   | Type | Description | Constraints |
   | --- | --- | --- |
   | nnnnnnnnnn | 10-digit object number of the next free object | 0-max |
   | ggggg |  5-digit generation number | 0-max |
   | f |  free or in-use entry | `f` or `n` |
3. The code should be covered with the unit, and mutation tests.