### PR TITLE
feat(file-structure): added xref subsection object

### DIFF
--- a/src/Off.Net.Pdf.Core/FileStructure/XRefEntry.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefEntry.cs
@@ -14,7 +14,7 @@ public sealed class XRefEntry : IPdfObject, IEquatable<XRefEntry>
 {
     #region Fields
 
-    private readonly int _hashCode;
+    private readonly Lazy<int> _hashCode;
     private readonly Lazy<string> _literalValue;
     private readonly Lazy<byte[]> _bytes;
 
@@ -29,12 +29,12 @@ public sealed class XRefEntry : IPdfObject, IEquatable<XRefEntry>
             .CheckConstraints(num => num <= 9999999999, Resource.XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue);
 
         GenerationNumber = generationNumber
-            .CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive)
+            .CheckConstraints(num => num >= 0, Resource.PdfIndirect_GenerationNumberMustBePositive)
             .CheckConstraints(num => num <= 65535, Resource.PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue);
 
         EntryType = entryType;
 
-        _hashCode = HashCode.Combine(nameof(XRefEntry).GetHashCode(), byteOffset.GetHashCode(), generationNumber.GetHashCode());
+        _hashCode = new Lazy<int>(() => HashCode.Combine(nameof(XRefEntry).GetHashCode(), byteOffset.GetHashCode(), generationNumber.GetHashCode()));
         _literalValue = new Lazy<string>(GenerateContent);
         _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
     }
@@ -61,7 +61,7 @@ public sealed class XRefEntry : IPdfObject, IEquatable<XRefEntry>
 
     public override int GetHashCode()
     {
-        return _hashCode;
+        return _hashCode.Value;
     }
 
     public override bool Equals(object? obj)

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefSubSection.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefSubSection.cs
@@ -1,0 +1,87 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class XRefSubSection : IPdfObject<ICollection<XRefEntry>>, IEquatable<XRefSubSection>
+{
+    #region Fields
+
+    private readonly Lazy<int> _hashCode;
+    private readonly Lazy<string> _literalValue;
+    private readonly Lazy<byte[]> _bytes;
+
+    #endregion
+
+    #region Constructors
+
+    public XRefSubSection(int objectNumber, ICollection<XRefEntry> xRefEntries)
+    {
+        ObjectNumber = objectNumber.CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive);
+        Value = xRefEntries.CheckConstraints(entry => entry.Count > 0, Resource.XRefSubSection_MustHaveNonEmptyEntriesCollection);
+        _hashCode = new Lazy<int>(() => HashCode.Combine(nameof(XRefSubSection).GetHashCode(), objectNumber.GetHashCode(), xRefEntries.GetHashCode()));
+        _literalValue = new Lazy<string>(GenerateContent);
+        _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int Length => Content.Length;
+
+    public ReadOnlyMemory<byte> Bytes => _bytes.Value;
+
+    public int ObjectNumber { get; }
+
+    public int NumberOfEntries => Value.Count;
+
+    public ICollection<XRefEntry> Value { get; }
+
+    public string Content => _literalValue.Value;
+
+    #endregion
+
+    #region Public Methods
+
+    public override int GetHashCode()
+    {
+        return _hashCode.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as XRefSubSection);
+    }
+
+    public bool Equals(XRefSubSection? other)
+    {
+        return other is not null &&
+               ObjectNumber == other.ObjectNumber &&
+               Value.SequenceEqual(other.Value);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private string GenerateContent()
+    {
+        StringBuilder stringBuilder = new StringBuilder()
+            .Append(this.ObjectNumber)
+            .Append(' ')
+            .Append(this.NumberOfEntries)
+            .Append('\n');
+
+        foreach (XRefEntry entry in Value)
+        {
+            stringBuilder.Append(entry.Content);
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XrefSubSection.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XrefSubSection.cs
@@ -1,6 +1,0 @@
-﻿namespace Off.Net.Pdf.Core.FileStructure;
-
-public sealed class XrefSubSection
-{
-
-}

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -78,7 +78,7 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The object number of the PDF indirect type must be positive.
+        ///   Looks up a localized string similar to The object number must be positive.
         /// </summary>
         internal static string PdfIndirect_ObjectNumberMustBePositive {
             get {
@@ -164,6 +164,15 @@ namespace Off.Net.Pdf.Core {
         internal static string XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue {
             get {
                 return ResourceManager.GetString("XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cross-reference subsection must have non-empty list of entries.
+        /// </summary>
+        internal static string XRefSubSection_MustHaveNonEmptyEntriesCollection {
+            get {
+                return ResourceManager.GetString("XRefSubSection_MustHaveNonEmptyEntriesCollection", resourceCulture);
             }
         }
     }

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -144,7 +144,7 @@
     <value>The PDF string type with Hex representation should have a value provided</value>
   </data>
   <data name="PdfIndirect_ObjectNumberMustBePositive" xml:space="preserve">
-    <value>The object number of the PDF indirect type must be positive</value>
+    <value>The object number must be positive</value>
   </data>
   <data name="PdfIndirect_GenerationNumberMustBePositive" xml:space="preserve">
     <value>The generation number must be positive</value>
@@ -157,5 +157,8 @@
   </data>
   <data name="XRefEntry_ByteOffsetMustNotExceedMaxAllowedValue" xml:space="preserve">
     <value>The byte offset must not exceed 9999999999</value>
+  </data>
+  <data name="XRefSubSection_MustHaveNonEmptyEntriesCollection" xml:space="preserve">
+    <value>The cross-reference subsection must have non-empty list of entries</value>
   </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
@@ -53,7 +53,7 @@ public class XRefEntryTests
 
         // Assert
         var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefEntryFunction);
-        Assert.StartsWith(Resource.PdfIndirect_ObjectNumberMustBePositive, exception.Message);
+        Assert.StartsWith(Resource.PdfIndirect_GenerationNumberMustBePositive, exception.Message);
     }
 
     [Theory(DisplayName = $"Constructor with overflowed {nameof(XRefEntry.GenerationNumber)} should throw an {nameof(ArgumentOutOfRangeException)}")]

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Off.Net.Pdf.Core.FileStructure;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.FileStructure;
+
+public class XRefSubSectionTests
+{
+    [Theory(DisplayName = $"Constructor with negative {nameof(XRefSubSection.ObjectNumber)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1)]
+    [InlineData(-15)]
+    [InlineData(-23)]
+    public void XRefSubSection_NegativeByteOffset_ShouldThrowException(int objectNumber)
+    {
+        // Arrange
+        ICollection<XRefEntry> entries = new List<XRefEntry>(1) { new(0, 0, XRefEntryType.Free) };
+
+        // Act
+        XRefSubSection XRefSubSectionFunction() => new(objectNumber, entries);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefSubSectionFunction);
+        Assert.StartsWith(Resource.PdfIndirect_ObjectNumberMustBePositive, exception.Message);
+    }
+
+    [Fact(DisplayName = $"Constructor with negative {nameof(XRefSubSection.NumberOfEntries)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    public void XRefSubSection_NegativeGenerationNumber_ShouldThrowException()
+    {
+        // Arrange
+        ICollection<XRefEntry> entries = new List<XRefEntry>(0);
+
+        // Act
+        XRefSubSection XRefSubSectionFunction() => new(0, entries);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefSubSectionFunction);
+        Assert.StartsWith(Resource.XRefSubSection_MustHaveNonEmptyEntriesCollection, exception.Message);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.Content)} property should return a valid value")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_Content_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_Content_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, string expectedContent)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        string actualContent = xRefEntry.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.Length)} property should return always 20")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_Length_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_Length_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, int expectedLength)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        int actualLength = xRefEntry.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.ObjectNumber)} property should return a valid value")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_ObjectNumber_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_ObjectNumber_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, int expectedObjectNumber)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        long actualObjectNumber = xRefEntry.ObjectNumber;
+
+        // Assert
+        Assert.Equal(expectedObjectNumber, actualObjectNumber);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.NumberOfEntries)} property should return a valid value")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_NumberOfEntries_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_NumberOfEntries_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, int expectedNumberOfEntries)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        long actualNumberOfEntries = xRefEntry.NumberOfEntries;
+
+        // Assert
+        Assert.Equal(expectedNumberOfEntries, actualNumberOfEntries);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.Bytes)} property should return a valid value")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_Bytes_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_Bytes_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, byte[] expectedBytes)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        byte[] actualBytes = xRefEntry.Bytes.ToArray();
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_NoExpectedData_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_GetHashCode_CheckValidity(int objectNumber, List<XRefEntry> entries)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+        int expectedHashCode = HashCode.Combine(nameof(XRefSubSection).GetHashCode(), objectNumber.GetHashCode(), entries.GetHashCode());
+
+        // Act
+        int actualHashCode = xRefEntry.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefSubSection.Content)} property, accessed multiple times, should return the same reference")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_NoExpectedData_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_Content_MultipleAccesses_ShouldReturnSameReference(int objectNumber, List<XRefEntry> entries)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        string actualContent1 = xRefEntry.Content;
+        string actualContent2 = xRefEntry.Content;
+
+        // Assert
+        Assert.True(ReferenceEquals(actualContent1, actualContent2));
+    }
+
+    [Theory(DisplayName = "Check if Equals returns a valid result")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_Equals_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_Equals_CheckValidity(int objectNumber1, int objectNumber2, List<XRefEntry> entries1, List<XRefEntry> entries2, bool expectedValue)
+    {
+        // Arrange
+        XRefSubSection xRefEntry1 = new(objectNumber1, entries1);
+        XRefSubSection xRefEntry2 = new(objectNumber2, entries2);
+
+        // Act
+        bool actualResult = xRefEntry1.Equals(xRefEntry2);
+
+        // Assert
+        Assert.Equal(expectedValue, actualResult);
+    }
+
+    [Theory(DisplayName = "Check if Equals method with null object returns always false")]
+    [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_NoExpectedData_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
+    public void XRefSubSection_EqualsNullObject_CheckValidity(int objectNumber, List<XRefEntry> entries)
+    {
+        // Arrange
+        XRefSubSection xRefEntry = new(objectNumber, entries);
+
+        // Act
+        bool actualResult1 = xRefEntry.Equals(null);
+
+        Debug.Assert(xRefEntry != null, nameof(xRefEntry) + " != null");
+        bool actualResult2 = xRefEntry.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult1);
+        Assert.False(actualResult2);
+    }
+}
+
+internal static class XRefSubSectionTestsDataGenerator
+{
+    public static IEnumerable<object[]> XRefSubSection_Content_TestCases()
+    {
+        yield return new object[] { 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, "0 1\n0000000000 65535 f \n" };
+        yield return new object[] { 3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, "3 1\n0000025325 00000 n \n" };
+        yield return new object[] { 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }, "23 2\n0000025518 00002 n \n0000025635 00000 n \n" };
+        yield return new object[] { 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }, "30 1\n0000025777 00000 n \n" };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_Length_TestCases()
+    {
+        yield return new object[] { 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, 24 };
+        yield return new object[] { 3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, 24 };
+        yield return new object[] { 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }, 45 };
+        yield return new object[] { 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }, 25 };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_ObjectNumber_TestCases()
+    {
+        yield return new object[] { 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, 0 };
+        yield return new object[] { 3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, 3 };
+        yield return new object[] { 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }, 23 };
+        yield return new object[] { 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }, 30 };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_NumberOfEntries_TestCases()
+    {
+        yield return new object[] { 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, 1 };
+        yield return new object[] { 3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, 1 };
+        yield return new object[] { 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }, 2 };
+        yield return new object[] { 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }, 1 };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_NoExpectedData_TestCases()
+    {
+        yield return new object[] { 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) } };
+        yield return new object[] { 3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) } };
+        yield return new object[] { 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) } };
+        yield return new object[] { 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) } };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_Equals_TestCases()
+    {
+        yield return new object[] { 0, 0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }, true };
+        yield return new object[] { 3, 1, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }, false };
+        yield return new object[]
+        {
+            23, 23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse) }, false
+        };
+        yield return new object[] { 30, 30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }, new List<XRefEntry> { new(25777, 65535, XRefEntryType.InUse) }, false };
+    }
+
+    public static IEnumerable<object[]> XRefSubSection_Bytes_TestCases()
+    {
+        yield return new object[]
+        {
+            0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) },
+            new byte[] { 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x66, 0x20, 0x0A }
+        };
+        yield return new object[]
+        {
+            3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) },
+            new byte[] { 0x33, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x33, 0x32, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A }
+        };
+        yield return new object[]
+        {
+            23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) },
+            new byte[]
+            {
+                0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20, 0x0A, 0x30, 0x30, 0x30, 0x30,
+                0x30, 0x32, 0x35, 0x36, 0x33, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
+            }
+        };
+        yield return new object[]
+        {
+            30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) },
+            new byte[] { 0x33, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x37, 0x37, 0x37, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A }
+        };
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.5.4`, the cross-reference subsection may appear in any order in a cross-reference section. If a document doesn't use `incremental updates`, the cross-reference section shall contain only one subsection.

Example:

```
0 1                             % Sub-section 1
0000000000 65535 f                  % Entry 1
3 1                             % Sub-section 2
0000025325 00000 n                  % Entry 1
23 2                            % Sub-section 3
0000025518 00002 n                  % Entry 1
0000025635 00000 n                  % Entry 2
30 1                            % Sub-section 4
0000025777 00000 n                  % Entry 1
```

### Acceptance criteria

1. Cross-Reference subsection shall begin with a line containing two numbers separated by a `space`:
   | Type | Description | Constraints |
   | --- | --- | --- |
   | nn | Number of the first object in the subsection | 0-max |
   | cc |  number of entries in the subsection | 0-max |
1. The subsection should contain the exact number of the `XRef` entries specified in the header (i.e. `23 2` means that the subsection should contain 2 entries)
1. The code should be covered with the unit and mutation tests

**Notes**: This story won't cover the `incremental updates`.

### Dependencies

- #27