### PR TITLE
feat(file-structure): added xref table object

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/tests/Off.Net.Pdf.Core.Tests/bin/Debug/net6.0/Off.Net.Pdf.Core.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/tests/Off.Net.Pdf.Core.Tests",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefExtensions.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefExtensions.cs
@@ -1,0 +1,64 @@
+﻿namespace Off.Net.Pdf.Core.FileStructure;
+
+public static class XRefExtensions
+{
+    public static XRefSubSection ToXRefSubSection(this XRefEntry entry, int objectNumber)
+    {
+        return new XRefSubSection(objectNumber, new List<XRefEntry>(1) { entry });
+    }
+
+    public static XRefSubSection ToXRefSubSection(this ICollection<XRefEntry> entries, int objectNumber)
+    {
+        return new XRefSubSection(objectNumber, entries);
+    }
+
+    public static XRefSection ToXRefSection(this XRefSubSection subSection)
+    {
+        return new XRefSection(new List<XRefSubSection>(1) { subSection });
+    }
+
+    public static XRefSection ToXRefSection(this ICollection<XRefSubSection> subSections)
+    {
+        return new XRefSection(subSections);
+    }
+
+    public static XRefSection ToXRefSection(this XRefEntry entry, int objectNumber)
+    {
+        return entry.ToXRefSubSection(objectNumber).ToXRefSection();
+    }
+
+    public static XRefSection ToXRefSection(this ICollection<XRefEntry> entries, int objectNumber)
+    {
+        return entries.ToXRefSubSection(objectNumber).ToXRefSection();
+    }
+
+    public static XRefTable ToXRefTable(this XRefSection section)
+    {
+        return new XRefTable(new List<XRefSection>(1) { section });
+    }
+
+    public static XRefTable ToXRefTable(this ICollection<XRefSection> sections)
+    {
+        return new XRefTable(sections);
+    }
+
+    public static XRefTable ToXRefTable(this XRefSubSection subSection)
+    {
+        return subSection.ToXRefSection().ToXRefTable();
+    }
+
+    public static XRefTable ToXRefTable(this ICollection<XRefSubSection> subSections)
+    {
+        return subSections.ToXRefSection().ToXRefTable();
+    }
+
+    public static XRefTable ToXRefTable(this XRefEntry entry, int objectNumber)
+    {
+        return entry.ToXRefSubSection(objectNumber).ToXRefSection().ToXRefTable();
+    }
+
+    public static XRefTable ToXRefTable(this ICollection<XRefEntry> entries, int objectNumber)
+    {
+        return entries.ToXRefSubSection(objectNumber).ToXRefSection().ToXRefTable();
+    }
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefSection.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefSection.cs
@@ -6,7 +6,7 @@ namespace Off.Net.Pdf.Core.FileStructure;
 
 public sealed class XRefSection : IPdfObject<ICollection<XRefSubSection>>, IEquatable<XRefSection>
 {
-#region Fields
+    #region Fields
 
     private readonly Lazy<int> _hashCode;
     private readonly Lazy<string> _literalValue;

--- a/src/Off.Net.Pdf.Core/FileStructure/XRefTable.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/XRefTable.cs
@@ -1,6 +1,78 @@
-﻿namespace Off.Net.Pdf.Core.FileStructure;
+﻿using System.Text;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
 
-public sealed class XRefTable
+namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class XRefTable : IPdfObject<ICollection<XRefSection>>, IEquatable<XRefTable>
 {
+    #region Fields
 
+    private readonly Lazy<int> _hashCode;
+    private readonly Lazy<string> _literalValue;
+    private readonly Lazy<byte[]> _bytes;
+
+    #endregion
+
+    #region Constructors
+
+    public XRefTable(ICollection<XRefSection> xRefSections)
+    {
+        Value = xRefSections.CheckConstraints(sections => sections.Count > 0, Resource.XRefTable_MustHaveNonEmptyEntriesCollection);
+        _hashCode = new Lazy<int>(() => HashCode.Combine(nameof(XRefTable).GetHashCode(), xRefSections.GetHashCode()));
+        _literalValue = new Lazy<string>(GenerateContent);
+        _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int Length => Content.Length;
+
+    public int NumberOfSections => Value.Count;
+
+    public ReadOnlyMemory<byte> Bytes => _bytes.Value;
+
+    public ICollection<XRefSection> Value { get; }
+
+    public string Content => _literalValue.Value;
+
+    #endregion
+
+    #region Public Methods
+
+    public override int GetHashCode()
+    {
+        return _hashCode.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as XRefTable);
+    }
+
+    public bool Equals(XRefTable? other)
+    {
+        return other is not null &&
+               Value.SequenceEqual(other.Value);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private string GenerateContent()
+    {
+        StringBuilder stringBuilder = new();
+
+        foreach (XRefSection section in Value)
+        {
+            stringBuilder.Append(section.Content);
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    #endregion
 }

--- a/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
@@ -66,7 +66,7 @@ public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEqu
             return _literalValue;
         }
 
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new();
 
         foreach (var item in Value)
         {

--- a/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
@@ -77,7 +77,7 @@ public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdf
             return _literalValue;
         }
 
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new();
 
         foreach (var item in Value)
         {

--- a/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfName.cs
@@ -100,7 +100,7 @@ public sealed class PdfName : IPdfObject<string>, IEquatable<PdfName>
             return _literalValue;
         }
 
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new();
 
         foreach (char ch in Value)
         {

--- a/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfString.cs
@@ -90,7 +90,7 @@ public sealed class PdfString : IPdfObject<string>, IEquatable<PdfString>
             return _literalValue;
         }
 
-        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder stringBuilder = new();
 
         for (int i = 0; i < Value.Length; i++)
         {

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -168,7 +168,7 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The cross-reference section must have non-empty list of entries.
+        ///   Looks up a localized string similar to The cross-reference subsection must have non-empty list of subsections.
         /// </summary>
         internal static string XRefSection_MustHaveNonEmptyEntriesCollection {
             get {
@@ -182,6 +182,15 @@ namespace Off.Net.Pdf.Core {
         internal static string XRefSubSection_MustHaveNonEmptyEntriesCollection {
             get {
                 return ResourceManager.GetString("XRefSubSection_MustHaveNonEmptyEntriesCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cross-reference table must have non-empty list of sections.
+        /// </summary>
+        internal static string XRefTable_MustHaveNonEmptyEntriesCollection {
+            get {
+                return ResourceManager.GetString("XRefTable_MustHaveNonEmptyEntriesCollection", resourceCulture);
             }
         }
     }

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -162,6 +162,9 @@
     <value>The cross-reference subsection must have non-empty list of entries</value>
   </data>
   <data name="XRefSection_MustHaveNonEmptyEntriesCollection" xml:space="preserve">
-    <value>The cross-reference section must have non-empty list of entries</value>
+    <value>The cross-reference subsection must have non-empty list of subsections</value>
+  </data>
+  <data name="XRefTable_MustHaveNonEmptyEntriesCollection" xml:space="preserve">
+    <value>The cross-reference table must have non-empty list of sections</value>
   </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSectionTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSectionTests.cs
@@ -24,10 +24,9 @@ public class XRefSectionTests
 
     [Theory(DisplayName = $"{nameof(XRefSection.Content)} property should return a valid value")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_Content_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_Content_ShouldReturnValidValue(List<XRefSubSection> subSections, string expectedContent)
+    public void XRefSection_Content_ShouldReturnValidValue(XRefSection xRefSection, string expectedContent)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         string actualContent = xRefSection.Content;
@@ -36,12 +35,11 @@ public class XRefSectionTests
         Assert.Equal(expectedContent, actualContent);
     }
 
-    [Theory(DisplayName = $"{nameof(XRefSection.Length)} property should return always 20")]
+    [Theory(DisplayName = $"{nameof(XRefSection.Length)} property should return a valid value")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_Length_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_Length_ShouldReturnValidValue(List<XRefSubSection> subSections, int expectedLength)
+    public void XRefSection_Length_ShouldReturnValidValue(XRefSection xRefSection, int expectedLength)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         int actualLength = xRefSection.Length;
@@ -51,11 +49,10 @@ public class XRefSectionTests
     }
 
     [Theory(DisplayName = $"{nameof(XRefSection.NumberOfSubSections)} property should return a valid value")]
-    [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_NumberOfEntries_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_NumberOfEntries_ShouldReturnValidValue(List<XRefSubSection> subSections, int expectedNumberOfEntries)
+    [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_NumberOfSubSections_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
+    public void XRefSection_NumberOfEntries_ShouldReturnValidValue(XRefSection xRefSection, int expectedNumberOfEntries)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         long actualNumberOfEntries = xRefSection.NumberOfSubSections;
@@ -66,10 +63,9 @@ public class XRefSectionTests
 
     [Theory(DisplayName = $"{nameof(XRefSection.Bytes)} property should return a valid value")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_Bytes_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_Bytes_ShouldReturnValidValue(List<XRefSubSection> subSections, byte[] expectedBytes)
+    public void XRefSection_Bytes_ShouldReturnValidValue(XRefSection xRefSection, byte[] expectedBytes)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         byte[] actualBytes = xRefSection.Bytes.ToArray();
@@ -81,11 +77,10 @@ public class XRefSectionTests
 
     [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_NoExpectedData_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_GetHashCode_CheckValidity(List<XRefSubSection> subSections)
+    public void XRefSection_GetHashCode_CheckValidity(XRefSection xRefSection)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
-        int expectedHashCode = HashCode.Combine(nameof(XRefSection).GetHashCode(), subSections.GetHashCode());
+        int expectedHashCode = HashCode.Combine(nameof(XRefSection).GetHashCode(), xRefSection.Value.GetHashCode());
 
         // Act
         int actualHashCode = xRefSection.GetHashCode();
@@ -96,10 +91,9 @@ public class XRefSectionTests
 
     [Theory(DisplayName = $"{nameof(XRefSection.Content)} property, accessed multiple times, should return the same reference")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_NoExpectedData_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_Content_MultipleAccesses_ShouldReturnSameReference(List<XRefSubSection> subSections)
+    public void XRefSection_Content_MultipleAccesses_ShouldReturnSameReference(XRefSection xRefSection)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         string actualContent1 = xRefSection.Content;
@@ -111,11 +105,9 @@ public class XRefSectionTests
 
     [Theory(DisplayName = "Check if Equals returns a valid result")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_Equals_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_Equals_CheckValidity(List<XRefSubSection> subSections1, List<XRefSubSection> subSections2, bool expectedValue)
+    public void XRefSection_Equals_CheckValidity(XRefSection xRefSection1, XRefSection xRefSection2, bool expectedValue)
     {
         // Arrange
-        XRefSection xRefSection1 = new(subSections1);
-        XRefSection xRefSection2 = new(subSections2);
 
         // Act
         bool actualResult = xRefSection1.Equals(xRefSection2);
@@ -126,10 +118,9 @@ public class XRefSectionTests
 
     [Theory(DisplayName = "Check if Equals method with null object returns always false")]
     [MemberData(nameof(XRefSectionTestsDataGenerator.XRefSection_NoExpectedData_TestCases), MemberType = typeof(XRefSectionTestsDataGenerator))]
-    public void XRefSection_EqualsNullObject_CheckValidity(List<XRefSubSection> subSections)
+    public void XRefSection_EqualsNullObject_CheckValidity(XRefSection xRefSection)
     {
         // Arrange
-        XRefSection xRefSection = new(subSections);
 
         // Act
         bool actualResult1 = xRefSection.Equals(null);
@@ -145,154 +136,70 @@ public class XRefSectionTests
 
 internal static class XRefSectionTestsDataGenerator
 {
+    private static readonly XRefEntry EntryObj0Gen65535F = new(0, 65535, XRefEntryType.Free);
+    private static readonly XRefEntry EntryObj25325Gen0N = new(25325, 0, XRefEntryType.InUse);
+    private static readonly XRefEntry EntryObj257775Gen0N = new(25777, 0, XRefEntryType.InUse);
+    private static readonly List<XRefEntry> MultipleEntries = new() { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) };
+
+    private static readonly List<XRefSubSection> MultipleSubSections = new()
+    {
+        EntryObj0Gen65535F.ToXRefSubSection(0), EntryObj25325Gen0N.ToXRefSubSection(3), EntryObj257775Gen0N.ToXRefSubSection(30), MultipleEntries.ToXRefSubSection(23)
+    };
+
     public static IEnumerable<object[]> XRefSection_Content_TestCases()
     {
-        yield return new object[] { new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) }, "xref\n0 1\n0000000000 65535 f \n" };
-        yield return new object[] { new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) }, "xref\n3 1\n0000025325 00000 n \n" };
-        yield return new object[] { new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) }, "xref\n30 1\n0000025777 00000 n \n" };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0), "xref\n0 1\n0000000000 65535 f \n" };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSection(3), "xref\n3 1\n0000025325 00000 n \n" };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefSection(30), "xref\n30 1\n0000025777 00000 n \n" };
+        yield return new object[] { MultipleEntries.ToXRefSection(23), "xref\n23 2\n0000025518 00002 n \n0000025635 00000 n \n" };
         yield return new object[]
         {
-            new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) },
-            "xref\n23 2\n0000025518 00002 n \n0000025635 00000 n \n"
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            "xref\n0 1\n0000000000 65535 f \n3 1\n0000025325 00000 n \n30 1\n0000025777 00000 n \n23 2\n0000025518 00002 n \n0000025635 00000 n \n"
+            MultipleSubSections.ToXRefSection(), "xref\n0 1\n0000000000 65535 f \n3 1\n0000025325 00000 n \n30 1\n0000025777 00000 n \n23 2\n0000025518 00002 n \n0000025635 00000 n \n"
         };
     }
 
     public static IEnumerable<object[]> XRefSection_Length_TestCases()
     {
-        yield return new object[] { new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) }, 29 };
-        yield return new object[] { new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) }, 29 };
-        yield return new object[] { new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) }, 30 };
-        yield return new object[] { new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) }, 50 };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            123
-        };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0), 29 };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSection(3), 29 };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefSection(30), 30 };
+        yield return new object[] { MultipleEntries.ToXRefSection(23), 50 };
+        yield return new object[] { MultipleSubSections.ToXRefSection(), 123 };
     }
 
-    public static IEnumerable<object[]> XRefSection_NumberOfEntries_TestCases()
+    public static IEnumerable<object[]> XRefSection_NumberOfSubSections_TestCases()
     {
-        yield return new object[] { new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) }, 1 };
-        yield return new object[] { new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) }, 1 };
-        yield return new object[] { new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) }, 1 };
-        yield return new object[] { new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) }, 1 };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            4
-        };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0), 1 };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSection(3), 1 };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefSection(30), 1 };
+        yield return new object[] { MultipleEntries.ToXRefSection(23), 1 };
+        yield return new object[] { MultipleSubSections.ToXRefSection(), 4 };
     }
 
     public static IEnumerable<object[]> XRefSection_NoExpectedData_TestCases()
     {
-        yield return new object[] { new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) } };
-        yield return new object[] { new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) } };
-        yield return new object[] { new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) } };
-        yield return new object[] { new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) } };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            }
-        };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0) };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSection(3) };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefSection(30) };
+        yield return new object[] { MultipleEntries.ToXRefSection(23) };
+        yield return new object[] { MultipleSubSections.ToXRefSection() };
     }
 
     public static IEnumerable<object[]> XRefSection_Equals_TestCases()
     {
-        yield return new object[]
-        {
-            new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) },
-            new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) },
-            true
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) },
-            new List<XRefSubSection> { new(3, new List<XRefEntry> { new(98765, 0, XRefEntryType.InUse) }) },
-            false
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) },
-            new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) },
-            true
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) },
-            new List<XRefSubSection> { new(1, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) },
-            false
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            true
-        };
-        yield return new object[]
-        {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 123, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(1234, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.Free) }),
-                new(123, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
-            false
-        };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0), EntryObj0Gen65535F.ToXRefSection(0), true };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(0), EntryObj0Gen65535F.ToXRefSection(326), false };
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSection(326), EntryObj25325Gen0N.ToXRefSection(326), false };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSection(326), EntryObj25325Gen0N.ToXRefSection(326), true };
+        yield return new object[] { MultipleEntries.ToXRefSection(326), MultipleEntries.ToXRefSection(326), true };
+        yield return new object[] { MultipleEntries.ToXRefSection(412), MultipleEntries.ToXRefSection(326), false };
     }
 
     public static IEnumerable<object[]> XRefSection_Bytes_TestCases()
     {
         yield return new object[]
         {
-            new List<XRefSubSection> { new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }) },
+            EntryObj0Gen65535F.ToXRefSection(0),
             new byte[]
             {
                 0x78, 0x72, 0x65, 0x66, 0x0A, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x66, 0x20, 0x0A
@@ -300,7 +207,7 @@ internal static class XRefSectionTestsDataGenerator
         };
         yield return new object[]
         {
-            new List<XRefSubSection> { new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }) },
+            EntryObj25325Gen0N.ToXRefSection(3),
             new byte[]
             {
                 0x78, 0x72, 0x65, 0x66, 0x0A, 0x33, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x33, 0x32, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
@@ -308,7 +215,7 @@ internal static class XRefSectionTestsDataGenerator
         };
         yield return new object[]
         {
-            new List<XRefSubSection> { new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }) },
+            EntryObj257775Gen0N.ToXRefSection(30),
             new byte[]
             {
                 0x78, 0x72, 0x65, 0x66, 0x0A, 0x33, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x37, 0x37, 0x37, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20,
@@ -317,7 +224,7 @@ internal static class XRefSectionTestsDataGenerator
         };
         yield return new object[]
         {
-            new List<XRefSubSection> { new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }) },
+            MultipleEntries.ToXRefSection(23),
             new byte[]
             {
                 0x78, 0x72, 0x65, 0x66, 0x0A, 0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20,
@@ -326,20 +233,14 @@ internal static class XRefSectionTestsDataGenerator
         };
         yield return new object[]
         {
-            new List<XRefSubSection>
-            {
-                new(0, new List<XRefEntry> { new(0, 65535, XRefEntryType.Free) }),
-                new(3, new List<XRefEntry> { new(25325, 0, XRefEntryType.InUse) }),
-                new(30, new List<XRefEntry> { new(25777, 0, XRefEntryType.InUse) }),
-                new(23, new List<XRefEntry> { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) }),
-            },
+            MultipleSubSections.ToXRefSection(),
             new byte[]
             {
-                0x78, 0x72, 0x65, 0x66, 0x0A, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x66, 0x20, 0x0A, 0x33,
-                0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x33, 0x32, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A, 0x33, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30,
-                0x30, 0x30, 0x30, 0x32, 0x35, 0x37, 0x37, 0x37, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A, 0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35,
-                0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x36, 0x33, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20,
-                0x6E, 0x20, 0x0A
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x66, 0x20, 0x0A,
+                0x33, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x33, 0x32, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A, 0x33, 0x30, 0x20, 0x31, 0x0A,
+                0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x37, 0x37, 0x37, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A, 0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30,
+                0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x36, 0x33, 0x35, 0x20, 0x30, 0x30,
+                0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
             }
         };
     }

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
@@ -53,7 +53,7 @@ public class XRefSubSectionTests
         Assert.Equal(expectedContent, actualContent);
     }
 
-    [Theory(DisplayName = $"{nameof(XRefSubSection.Length)} property should return always 20")]
+    [Theory(DisplayName = $"{nameof(XRefSubSection.Length)} property should return a valid value")]
     [MemberData(nameof(XRefSubSectionTestsDataGenerator.XRefSubSection_Length_TestCases), MemberType = typeof(XRefSubSectionTestsDataGenerator))]
     public void XRefSubSection_Length_ShouldReturnValidValue(int objectNumber, List<XRefEntry> entries, int expectedLength)
     {

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefTableTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefTableTests.cs
@@ -1,0 +1,277 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Off.Net.Pdf.Core.FileStructure;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.FileStructure;
+
+public class XRefTableTests
+{
+    [Fact(DisplayName = $"Constructor with negative {nameof(XRefTable.NumberOfSections)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    public void XRefTable_NegativeGenerationNumber_ShouldThrowException()
+    {
+        // Arrange
+        ICollection<XRefSection> sections = new List<XRefSection>(0);
+
+        // Act
+        XRefTable XRefTableFunction() => new(sections);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(XRefTableFunction);
+        Assert.StartsWith(Resource.XRefTable_MustHaveNonEmptyEntriesCollection, exception.Message);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefTable.Content)} property should return a valid value")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_Content_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_Content_ShouldReturnValidValue(XRefTable xRefTable, string expectedContent)
+    {
+        // Arrange
+
+        // Act
+        string actualContent = xRefTable.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefTable.Length)} property should return a valid value")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_Length_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_Length_ShouldReturnValidValue(XRefTable xRefTable, int expectedLength)
+    {
+        // Arrange
+
+        // Act
+        int actualLength = xRefTable.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefTable.NumberOfSections)} property should return a valid value")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_NumberOfSections_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_NumberOfEntries_ShouldReturnValidValue(XRefTable xRefTable, int expectedNumberOfEntries)
+    {
+        // Arrange
+
+        // Act
+        long actualNumberOfEntries = xRefTable.NumberOfSections;
+
+        // Assert
+        Assert.Equal(expectedNumberOfEntries, actualNumberOfEntries);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefTable.Bytes)} property should return a valid value")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_Bytes_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_Bytes_ShouldReturnValidValue(XRefTable xRefTable, byte[] expectedBytes)
+    {
+        // Arrange
+
+        // Act
+        byte[] actualBytes = xRefTable.Bytes.ToArray();
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_NoExpectedData_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_GetHashCode_CheckValidity(XRefTable xRefTable)
+    {
+        // Arrange
+        int expectedHashCode = HashCode.Combine(nameof(XRefTable).GetHashCode(), xRefTable.Value.GetHashCode());
+
+        // Act
+        int actualHashCode = xRefTable.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Theory(DisplayName = $"{nameof(XRefTable.Content)} property, accessed multiple times, should return the same reference")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_NoExpectedData_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_Content_MultipleAccesses_ShouldReturnSameReference(XRefTable xRefTable)
+    {
+        // Arrange
+
+        // Act
+        string actualContent1 = xRefTable.Content;
+        string actualContent2 = xRefTable.Content;
+
+        // Assert
+        Assert.True(ReferenceEquals(actualContent1, actualContent2));
+    }
+
+    [Theory(DisplayName = "Check if Equals returns a valid result")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_Equals_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_Equals_CheckValidity(XRefTable xRefTable1, XRefTable xRefTable2, bool expectedValue)
+    {
+        // Arrange
+
+        // Act
+        bool actualResult = xRefTable1.Equals(xRefTable2);
+
+        // Assert
+        Assert.Equal(expectedValue, actualResult);
+    }
+
+    [Theory(DisplayName = "Check if Equals method with null object returns always false")]
+    [MemberData(nameof(XRefTableTestsDataGenerator.XRefTable_NoExpectedData_TestCases), MemberType = typeof(XRefTableTestsDataGenerator))]
+    public void XRefTable_EqualsNullObject_CheckValidity(XRefTable xRefTable)
+    {
+        // Arrange
+
+        // Act
+        bool actualResult1 = xRefTable.Equals(null);
+
+        Debug.Assert(xRefTable != null, nameof(xRefTable) + " != null");
+        bool actualResult2 = xRefTable.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult1);
+        Assert.False(actualResult2);
+    }
+}
+
+internal static class XRefTableTestsDataGenerator
+{
+    private static readonly XRefEntry EntryObj0Gen65535F = new(0, 65535, XRefEntryType.Free);
+    private static readonly XRefEntry EntryObj25325Gen0N = new(25325, 0, XRefEntryType.InUse);
+    private static readonly XRefEntry EntryObj257775Gen0N = new(25777, 0, XRefEntryType.InUse);
+    private static readonly List<XRefEntry> MultipleEntries = new() { new(25518, 2, XRefEntryType.InUse), new(25635, 0, XRefEntryType.InUse) };
+    private static readonly List<XRefSubSection> MultipleSubSections = new()
+    {
+        EntryObj0Gen65535F.ToXRefSubSection(0), EntryObj25325Gen0N.ToXRefSubSection(3), EntryObj257775Gen0N.ToXRefSubSection(30), MultipleEntries.ToXRefSubSection(23)
+    };
+    private static readonly List<XRefSection> MultipleSections = new() { MultipleEntries.ToXRefSection(23), MultipleEntries.ToXRefSection(41) };
+
+    public static IEnumerable<object[]> XRefTable_Content_TestCases()
+    {
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSubSection(0).ToXRefSection().ToXRefTable(), "xref\n0 1\n0000000000 65535 f \n" };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSubSection(3).ToXRefTable(), "xref\n3 1\n0000025325 00000 n \n" };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefTable(30), "xref\n30 1\n0000025777 00000 n \n" };
+        yield return new object[] { MultipleEntries.ToXRefTable(23), "xref\n23 2\n0000025518 00002 n \n0000025635 00000 n \n" };
+        yield return new object[] { MultipleSubSections.ToXRefTable(), "xref\n0 1\n0000000000 65535 f \n3 1\n0000025325 00000 n \n30 1\n0000025777 00000 n \n23 2\n0000025518 00002 n \n0000025635 00000 n \n" };
+        yield return new object[] { MultipleSections.ToXRefTable(), "xref\n23 2\n0000025518 00002 n \n0000025635 00000 n \nxref\n41 2\n0000025518 00002 n \n0000025635 00000 n \n" };
+    }
+
+    public static IEnumerable<object[]> XRefTable_Length_TestCases()
+    {
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSubSection(0).ToXRefSection().ToXRefTable(), 29 };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSubSection(3).ToXRefTable(), 29 };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefTable(30), 30 };
+        yield return new object[] { MultipleEntries.ToXRefTable(23), 50 };
+        yield return new object[] { MultipleSubSections.ToXRefTable(), 123 };
+        yield return new object[] { MultipleSections.ToXRefTable(), 100 };
+    }
+
+    public static IEnumerable<object[]> XRefTable_NumberOfSections_TestCases()
+    {
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSubSection(0).ToXRefSection().ToXRefTable(), 1 };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSubSection(3).ToXRefTable(), 1 };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefTable(30), 1 };
+        yield return new object[] { MultipleEntries.ToXRefTable(23), 1 };
+        yield return new object[] { MultipleSubSections.ToXRefTable(), 1 };
+        yield return new object[] { MultipleSections.ToXRefTable(), 2 };
+    }
+
+    public static IEnumerable<object[]> XRefTable_NoExpectedData_TestCases()
+    {
+        yield return new object[] { EntryObj0Gen65535F.ToXRefSubSection(0).ToXRefSection().ToXRefTable() };
+        yield return new object[] { EntryObj25325Gen0N.ToXRefSubSection(3).ToXRefTable() };
+        yield return new object[] { EntryObj257775Gen0N.ToXRefTable(30) };
+        yield return new object[] { MultipleEntries.ToXRefTable(23) };
+        yield return new object[] { MultipleSubSections.ToXRefTable() };
+        yield return new object[] { MultipleSections.ToXRefTable() };
+    }
+
+    public static IEnumerable<object[]> XRefTable_Equals_TestCases()
+    {
+        yield return new object[]
+        {
+            EntryObj0Gen65535F.ToXRefTable(0),
+            EntryObj0Gen65535F.ToXRefTable(0),
+            true
+        };
+        yield return new object[]
+        {
+            EntryObj0Gen65535F.ToXRefTable(0),
+            EntryObj0Gen65535F.ToXRefTable(560),
+            false
+        };
+        yield return new object[]
+        {
+            EntryObj0Gen65535F.ToXRefTable(0),
+            EntryObj25325Gen0N.ToXRefTable(0),
+            false
+        };
+        yield return new object[]
+        {
+            MultipleEntries.ToXRefTable(0),
+            MultipleEntries.ToXRefTable(0),
+            true
+        };
+        yield return new object[]
+        {
+            MultipleEntries.ToXRefTable(0),
+            MultipleEntries.ToXRefTable(560),
+            false
+        };
+        yield return new object[]
+        {
+            MultipleSections.ToXRefTable(),
+            MultipleSections.ToXRefTable(),
+            true
+        };
+    }
+
+    public static IEnumerable<object[]> XRefTable_Bytes_TestCases()
+    {
+        yield return new object[]
+        {
+            EntryObj0Gen65535F.ToXRefSubSection(0).ToXRefSection().ToXRefTable(),
+            new byte[]
+            {
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x36, 0x35, 0x35, 0x33, 0x35, 0x20, 0x66, 0x20, 0x0A
+            }
+        };
+        yield return new object[]
+        {
+            EntryObj25325Gen0N.ToXRefSubSection(3).ToXRefTable(),
+            new byte[]
+            {
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x33, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x33, 0x32, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
+            }
+        };
+        yield return new object[]
+        {
+            EntryObj257775Gen0N.ToXRefTable(30),
+            new byte[]
+            {
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x33, 0x30, 0x20, 0x31, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x37, 0x37, 0x37, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20,
+                0x0A
+            }
+        };
+        yield return new object[]
+        {
+            MultipleEntries.ToXRefTable(23),
+            new byte[]
+            {
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20,
+                0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x36, 0x33, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
+            }
+        };
+        yield return new object[]
+        {
+            MultipleSections.ToXRefTable(),
+            new byte[]
+            {
+                0x78, 0x72, 0x65, 0x66, 0x0A, 0x32, 0x33, 0x20, 0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20,
+                0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x36, 0x33, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A, 0x78, 0x72, 0x65, 0x66, 0x0A, 0x34, 0x31, 0x20,
+                0x32, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35, 0x35, 0x31, 0x38, 0x20, 0x30, 0x30, 0x30, 0x30, 0x32, 0x20, 0x6E, 0x20, 0x0A, 0x30, 0x30, 0x30, 0x30, 0x30, 0x32, 0x35,
+                0x36, 0x33, 0x35, 0x20, 0x30, 0x30, 0x30, 0x30, 0x30, 0x20, 0x6E, 0x20, 0x0A
+            }
+        };
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
@@ -179,7 +179,7 @@ public class PdfBooleanTests
     public void PdfBoolean_CheckImplicitOperator(bool value1)
     {
         // Arrange
-        PdfBoolean pdfBoolean1 = new PdfBoolean(value1);
+        PdfBoolean pdfBoolean1 = new(value1);
 
         // Act
         bool actualValue = pdfBoolean1; // Use an implicit conversion from PdfBoolean to bool

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
@@ -191,7 +191,7 @@ public class PdfIntegerTests
     public void PdfInteger_CheckImplicitOperator(int value1)
     {
         // Arrange
-        PdfInteger pdfInteger1 = new PdfInteger(value1);
+        PdfInteger pdfInteger1 = new(value1);
 
         // Act
         int actualValue = pdfInteger1; // Use an implicit conversion from PdfInteger to int
@@ -213,7 +213,7 @@ public class PdfIntegerTests
     public void PdfInteger_CompareTo_CheckValidity(int value1, int value2, int expectedValue)
     {
         // Arrange
-        PdfInteger pdfInteger1 = new PdfInteger(value1);
+        PdfInteger pdfInteger1 = new(value1);
         object pdfInteger2 = new PdfInteger(value2);
 
         // Act
@@ -227,7 +227,7 @@ public class PdfIntegerTests
     public void PdfInteger_CompareTo_ThrowsException()
     {
         // Arrange
-        PdfInteger pdfInteger1 = new PdfInteger();
+        PdfInteger pdfInteger1 = new();
         object pdfInteger2 = 5;
 
         // Act

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
@@ -229,7 +229,7 @@ public class PdfNameTests
     public void PdfName_CheckImplicitOperator(string value1)
     {
         // Arrange
-        PdfName pdfName1 = new PdfName(value1);
+        PdfName pdfName1 = new(value1);
 
         // Act
         string actualValue = pdfName1; // Use an implicit conversion from PdfName to string

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
@@ -185,7 +185,7 @@ public class PdfRealTests
     public void PdfReal_CheckImplicitOperator(float value1)
     {
         // Arrange
-        PdfReal pdfReal1 = new PdfReal(value1);
+        PdfReal pdfReal1 = new(value1);
 
         // Act
         float actualValue = pdfReal1; // Use an implicit conversion from PdfReal to float
@@ -205,7 +205,7 @@ public class PdfRealTests
     public void PdfReal_CompareTo_CheckValidity(float value1, float value2, float expectedValue)
     {
         // Arrange
-        PdfReal pdfReal1 = new PdfReal(value1);
+        PdfReal pdfReal1 = new(value1);
         object pdfReal2 = new PdfReal(value2);
 
         // Act
@@ -219,7 +219,7 @@ public class PdfRealTests
     public void PdfReal_CompareTo_ThrowsException()
     {
         // Arrange
-        PdfReal pdfReal1 = new PdfReal();
+        PdfReal pdfReal1 = new();
         object pdfReal2 = 5;
 
         // Act
@@ -256,7 +256,7 @@ public class PdfRealTests
     public void PdfReal_Constructor_CheckApproximation(float value1)
     {
         // Arrange
-        PdfReal pdfReal1 = new PdfReal(value1);
+        PdfReal pdfReal1 = new(value1);
 
         // Act
         float actualValue = pdfReal1.Value;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
@@ -216,7 +216,7 @@ public class PdfStringTests
     public void PdfString_CheckImplicitOperator(string value1)
     {
         // Arrange
-        PdfString pdfString1 = new PdfString(value1);
+        PdfString pdfString1 = new(value1);
 
         // Act
         string actualValue = pdfString1; // Use an implicit conversion from PdfString to string


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.5.4`, the cross-reference table contains information that permits random access to indirect objects within the file so that the entire file need not be read to locate any particular object.

Cross-Reference entry signature:

```
nnnnnnnnnn ggggg f eol
```

Cross-reference table example:

```
xref                        % Section 1
0 1                             % Sub-section 1
0000000000 65535 f                  % Entry 1
3 1                             % Sub-section 2
0000025325 00000 n                  % Entry 1
23 2                            % Sub-section 3
0000025518 00002 n                  % Entry 1
0000025635 00000 n                  % Entry 2
30 1                            % Sub-section 4
0000025777 00000 n                  % Entry 1

xref                        % Section 2
0 1                             % Sub-section 1
0000000000 65535 f                  % Entry 1
3 1                             % Sub-section 2
0000025325 00000 n                  % Entry 1
23 2                            % Sub-section 3
0000025518 00002 n                  % Entry 1
0000025635 00000 n                  % Entry 2
30 1                            % Sub-section 4
0000025777 00000 n                  % Entry 1
```

### Acceptance criteria

1. Cross-Reference entry signature should be `20` bytes in length.
2. Cross-Reference entry should consist of the following parts separated by the `space` character:
   | Type | Description | Constraints |
   | --- | --- | --- |
   | nnnnnnnnnn | 10-digit object number of the next free object | 0-max |
   | ggggg |  5-digit generation number | 0-max |
   | f |  free or in-use entry | `f` or `n` |
3. The code should be covered with the unit, and mutation tests.
4. This user story will ignore the incremental updates feature.

### Dependencies

- [x] #27
- [x] #28
- [x] #29