### PR TITLE
feat(file-structure): added file trailer object

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-stryker": {
-      "version": "3.4.0",
+      "version": "3.6.0",
       "commands": [
         "dotnet-stryker"
       ]

--- a/src/Off.Net.Pdf.Core/FileStructure/FileTrailer.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/FileTrailer.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class FileTrailer : IPdfObject, IEquatable<FileTrailer?>
+{
+    #region Fields
+
+    private static readonly PdfName Size = new("Size");
+    private static readonly PdfName Prev = new("Prev");
+    private static readonly PdfName Root = new("Root");
+    private static readonly PdfName Encrypt = new("Encrypt");
+    private static readonly PdfName Info = new("Info");
+    private static readonly PdfName Id = new("ID");
+
+    private readonly FileTrailerOptions _fileTrailerOptions;
+    private readonly Lazy<int> _hashCode;
+    private readonly Lazy<string> _literalValue;
+    private readonly Lazy<byte[]> _bytes;
+    private readonly Lazy<PdfDictionary<IPdfObject>> _fileTrailerDictionary;
+
+    #endregion
+
+    #region Constructors
+
+    public FileTrailer(long byteOffset, Action<FileTrailerOptions> fileTrailerOptionsFunc) : this(byteOffset, GetFileTrailerOptions(fileTrailerOptionsFunc))
+    {
+    }
+
+    public FileTrailer(long byteOffset, FileTrailerOptions fileTrailerOptions)
+    {
+        _fileTrailerOptions = fileTrailerOptions;
+
+        ByteOffset = byteOffset.CheckConstraints(num => num >= 0, Resource.FileTrailer_ByteOffsetMustBePositive);
+        _fileTrailerOptions
+            .CheckConstraints(option => option.Size > 0, Resource.FileTrailer_SizeMustBeGreaterThanZero)
+            .CheckConstraints(option => option.Prev == null || option.Prev >= 0, Resource.FileTrailer_PrevMustBePositive)
+            .CheckConstraints(option => option.Encrypt == null || option.Encrypt.Value.Count > 0, Resource.FileTrailer_EncryptMustHaveANonEmptyCollection)
+            .CheckConstraints(option => option.Encrypt == null || option.Id?.Value.Count == 2, Resource.FileTrailer_IdMustBeAnArrayOfTwoByteStrings);
+
+        _hashCode = new Lazy<int>(() => HashCode.Combine(nameof(FileTrailer).GetHashCode(), Content.GetHashCode()));
+        _literalValue = new Lazy<string>(GenerateContent);
+        _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
+        _fileTrailerDictionary = new Lazy<PdfDictionary<IPdfObject>>(GenerateFileTrailerDictionary);
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int Length => Content.Length;
+
+    public long ByteOffset { get; }
+
+    public PdfDictionary<IPdfObject> FileTrailerDictionary => _fileTrailerDictionary.Value;
+
+    public ReadOnlyMemory<byte> Bytes => _bytes.Value;
+
+    public string Content => _literalValue.Value;
+
+    #endregion
+
+    #region Public Methods
+
+    public override int GetHashCode()
+    {
+        return _hashCode.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as FileTrailer);
+    }
+
+    public bool Equals(FileTrailer? other)
+    {
+        return other is not null && GetHashCode() == other.GetHashCode();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private string GenerateContent()
+    {
+        return new StringBuilder()
+            .Insert(0, "trailer")
+            .Append('\n')
+            .Append(_fileTrailerDictionary.Value.Content)
+            .Append('\n')
+            .Append("startxref")
+            .Append('\n')
+            .Append(ByteOffset)
+            .Append('\n')
+            .Append("%%EOF")
+            .ToString();
+    }
+
+    private PdfDictionary<IPdfObject> GenerateFileTrailerDictionary()
+    {
+        return new Dictionary<PdfName, IPdfObject>(6)
+            .WithKeyValue(Size, _fileTrailerOptions.Size)
+            .WithKeyValue(Prev, _fileTrailerOptions.Prev)
+            .WithKeyValue(Root, _fileTrailerOptions.Root)
+            .WithKeyValue(Encrypt, _fileTrailerOptions.Encrypt)
+            .WithKeyValue(Info, _fileTrailerOptions.Info)
+            .WithKeyValue(Id, _fileTrailerOptions.Id)
+            .ToPdfDictionary();
+    }
+
+    private static FileTrailerOptions GetFileTrailerOptions(Action<FileTrailerOptions> optionsFunc)
+    {
+        FileTrailerOptions fileTrailerOptions = new();
+        optionsFunc.Invoke(fileTrailerOptions);
+        return fileTrailerOptions;
+    }
+
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/FileStructure/FileTrailerExtensions.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/FileTrailerExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.FileStructure;
+
+public sealed class FileTrailerOptions
+{
+    public PdfInteger Size { get; set; }
+
+    public PdfInteger? Prev { get; set; }
+
+    public PdfIndirectIdentifier<PdfDictionary<IPdfObject>> Root { get; set; } = new Dictionary<PdfName, IPdfObject>(0)
+        .ToPdfDictionary()
+        .ToPdfIndirect(0)
+        .ToPdfIndirectIdentifier();
+
+    public PdfDictionary<IPdfObject>? Encrypt { get; set; }
+
+    public PdfIndirectIdentifier<PdfDictionary<IPdfObject>>? Info { get; set; }
+
+    public PdfArray<PdfString>? Id { get; set; }
+}
+
+public static class FileTrailerExtensions
+{
+    public static FileTrailer ToFileTrailer(this FileTrailerOptions fileTrailerOptions, long byteOffset)
+    {
+        return new FileTrailer(byteOffset, fileTrailerOptions);
+    }
+}

--- a/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfArrayExtensions.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfArrayExtensions.cs
@@ -4,13 +4,13 @@ namespace Off.Net.Pdf.Core.Primitives;
 
 public static class PdfArrayExtensions
 {
-    public static PdfArray ToPdfArray(this IEnumerable<IPdfObject> items)
+    public static PdfArray<TValue> ToPdfArray<TValue>(this IEnumerable<TValue> items) where TValue: IPdfObject
     {
-        return PdfArray.CreateRange(items.ToList());
+        return PdfArray<TValue>.CreateRange(items.ToList());
     }
 
-    public static PdfArray ToPdfArray(this IPdfObject item)
+    public static PdfArray<TValue> ToPdfArray<TValue>(this TValue item) where TValue: IPdfObject
     {
-        return PdfArray.Create(item);
+        return PdfArray<TValue>.Create(item);
     }
 }

--- a/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfDictionaryExtensions.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfDictionaryExtensions.cs
@@ -4,13 +4,13 @@ namespace Off.Net.Pdf.Core.Primitives;
 
 public static class PdfDictionaryExtensions
 {
-    public static PdfDictionary ToPdfDictionary(this IDictionary<PdfName, IPdfObject> items)
+    public static PdfDictionary<TValue> ToPdfDictionary<TValue>(this IDictionary<PdfName, TValue> items) where TValue: IPdfObject
     {
-        return PdfDictionary.CreateRange(items);
+        return PdfDictionary<TValue>.CreateRange(items);
     }
 
-    public static PdfDictionary ToPdfDictionary(this KeyValuePair<PdfName, IPdfObject> item)
+    public static PdfDictionary<TValue> ToPdfDictionary<TValue>(this KeyValuePair<PdfName, TValue> item) where TValue: IPdfObject
     {
-        return PdfDictionary.Create(item);
+        return PdfDictionary<TValue>.Create(item);
     }
 }

--- a/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfIndirectExtensions.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfIndirectExtensions.cs
@@ -4,8 +4,13 @@ namespace Off.Net.Pdf.Core.Primitives;
 
 public static class PdfIndirectExtensions
 {
-    public static PdfIndirect ToPdfIndirect(this IPdfObject pdfObject, int objectNumber, int generationNumber = 0)
+    public static PdfIndirect<T> ToPdfIndirect<T>(this T pdfObject, int objectNumber, int generationNumber = 0) where T : IPdfObject
     {
-        return new PdfIndirect(pdfObject, objectNumber, generationNumber);
+        return new PdfIndirect<T>(pdfObject, objectNumber, generationNumber);
+    }
+
+    public static PdfIndirectIdentifier<T> ToPdfIndirectIdentifier<T>(this PdfIndirect<T> pdfIndirect) where T : IPdfObject
+    {
+        return new PdfIndirectIdentifier<T>(pdfIndirect);
     }
 }

--- a/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfStreamExtensions.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/Extensions/PdfStreamExtensions.cs
@@ -4,11 +4,11 @@ namespace Off.Net.Pdf.Core.Primitives;
 
 public sealed class PdfStreamExtentOptions
 {
-    public EitherType<PdfName, PdfArray>? Filter { get; set; } // Name or Array
-    public EitherType<PdfDictionary, PdfArray>? DecodeParameters { get; set; } // Dictionary or Array
+    public EitherType<PdfName, PdfArray<PdfName>>? Filter { get; set; } // Name or Array
+    public EitherType<PdfDictionary<PdfName>, PdfArray<PdfName>>? DecodeParameters { get; set; } // Dictionary or Array
     public PdfString? FileSpecification { get; set; }
-    public EitherType<PdfName, PdfArray>? FileFilter { get; set; } // Name or Array
-    public EitherType<PdfDictionary, PdfArray>? FileDecodeParameters { get; set; } // Dictionary or Array
+    public EitherType<PdfName, PdfArray<PdfName>>? FileFilter { get; set; } // Name or Array
+    public EitherType<PdfDictionary<PdfName>, PdfArray<PdfName>>? FileDecodeParameters { get; set; } // Dictionary or Array
 }
 
 internal static class PdfStreamInternalExtensions

--- a/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
@@ -3,7 +3,7 @@ using Off.Net.Pdf.Core.Interfaces;
 
 namespace Off.Net.Pdf.Core.Primitives;
 
-public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEquatable<PdfArray?>
+public sealed class PdfArray<TValue> : IPdfObject<IReadOnlyCollection<TValue>>, IEquatable<PdfArray<TValue>?> where TValue: IPdfObject
 {
     #region Fields
     private readonly int _hashCode;
@@ -12,10 +12,10 @@ public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEqu
     #endregion
 
     #region Constructors
-    public PdfArray(IReadOnlyCollection<IPdfObject> value)
+    public PdfArray(IReadOnlyCollection<TValue> value)
     {
         Value = value;
-        _hashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value.GetHashCode());
+        _hashCode = HashCode.Combine(nameof(PdfArray<TValue>).GetHashCode(), value.GetHashCode());
         _bytes = null;
     }
     #endregion
@@ -23,7 +23,7 @@ public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEqu
     #region Properties
     public int Length => Content.Length;
 
-    public IReadOnlyCollection<IPdfObject> Value { get; }
+    public IReadOnlyCollection<TValue> Value { get; }
 
     public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
@@ -38,23 +38,23 @@ public sealed class PdfArray : IPdfObject<IReadOnlyCollection<IPdfObject>>, IEqu
 
     public override bool Equals(object? obj)
     {
-        return Equals(obj as PdfArray);
+        return Equals(obj as PdfArray<TValue>);
     }
 
-    public bool Equals(PdfArray? other)
+    public bool Equals(PdfArray<TValue>? other)
     {
         return other is not null &&
-               EqualityComparer<IReadOnlyCollection<IPdfObject>>.Default.Equals(Value, other.Value);
+               EqualityComparer<IReadOnlyCollection<TValue>>.Default.Equals(Value, other.Value);
     }
 
-    public static PdfArray CreateRange(IEnumerable<IPdfObject> items)
+    public static PdfArray<TValue> CreateRange(IEnumerable<TValue> items)
     {
-        return new PdfArray(items.ToList());
+        return new PdfArray<TValue>(items.ToList());
     }
 
-    public static PdfArray Create(IPdfObject item)
+    public static PdfArray<TValue> Create(TValue item)
     {
-        return new PdfArray(new List<IPdfObject>(1) { item });
+        return new PdfArray<TValue>(new List<TValue>(1) { item });
     }
     #endregion
 

--- a/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfDictionary.cs
@@ -4,7 +4,7 @@ using Off.Net.Pdf.Core.Interfaces;
 
 namespace Off.Net.Pdf.Core.Primitives;
 
-public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdfObject>>, IEquatable<PdfDictionary?>
+public sealed class PdfDictionary<TValue> : IPdfObject<IReadOnlyDictionary<PdfName, TValue>>, IEquatable<PdfDictionary<TValue>?> where TValue: IPdfObject
 {
     #region Fields
 
@@ -16,10 +16,10 @@ public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdf
 
     #region Constructors
 
-    public PdfDictionary(IReadOnlyDictionary<PdfName, IPdfObject> value)
+    public PdfDictionary(IReadOnlyDictionary<PdfName, TValue> value)
     {
         Value = value;
-        _hashCode = HashCode.Combine(nameof(PdfDictionary).GetHashCode(), value.GetHashCode());
+        _hashCode = HashCode.Combine(nameof(PdfDictionary<TValue>).GetHashCode(), value.GetHashCode());
         _bytes = null;
     }
 
@@ -29,7 +29,7 @@ public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdf
 
     public int Length => Content.Length;
 
-    public IReadOnlyDictionary<PdfName, IPdfObject> Value { get; }
+    public IReadOnlyDictionary<PdfName, TValue> Value { get; }
 
     public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
@@ -46,24 +46,24 @@ public sealed class PdfDictionary : IPdfObject<IReadOnlyDictionary<PdfName, IPdf
 
     public override bool Equals(object? obj)
     {
-        return Equals(obj as PdfDictionary);
+        return Equals(obj as PdfDictionary<TValue>);
     }
 
-    public bool Equals(PdfDictionary? other)
+    public bool Equals(PdfDictionary<TValue>? other)
     {
         return other is not null &&
-               EqualityComparer<IReadOnlyDictionary<PdfName, IPdfObject>>.Default.Equals(Value, other.Value);
+               EqualityComparer<IReadOnlyDictionary<PdfName, TValue>>.Default.Equals(Value, other.Value);
     }
 
-    public static PdfDictionary CreateRange(IDictionary<PdfName, IPdfObject> items)
+    public static PdfDictionary<TValue> CreateRange(IDictionary<PdfName, TValue> items)
     {
-        return new PdfDictionary(new ReadOnlyDictionary<PdfName, IPdfObject>(items));
+        return new PdfDictionary<TValue>(new ReadOnlyDictionary<PdfName, TValue>(items));
     }
 
-    public static PdfDictionary Create(KeyValuePair<PdfName, IPdfObject> item)
+    public static PdfDictionary<TValue> Create(KeyValuePair<PdfName, TValue> item)
     {
-        IDictionary<PdfName, IPdfObject> dictionary = new Dictionary<PdfName, IPdfObject>(1) { { item.Key, item.Value } };
-        return new PdfDictionary(new ReadOnlyDictionary<PdfName, IPdfObject>(dictionary));
+        IDictionary<PdfName, TValue> dictionary = new Dictionary<PdfName, TValue>(1) { { item.Key, item.Value } };
+        return new PdfDictionary<TValue>(new ReadOnlyDictionary<PdfName, TValue>(dictionary));
     }
 
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfIndirect.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfIndirect.cs
@@ -4,7 +4,7 @@ using Off.Net.Pdf.Core.Interfaces;
 
 namespace Off.Net.Pdf.Core.Primitives;
 
-public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect>
+public sealed class PdfIndirect<T> : IPdfObject<T>, IEquatable<PdfIndirect<T>> where T: IPdfObject
 {
     #region Fields
 
@@ -16,7 +16,7 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
 
     #region Constructors
 
-    public PdfIndirect(IPdfObject pdfObject, int objectNumber, int generationNumber = 0)
+    public PdfIndirect(T pdfObject, int objectNumber, int generationNumber = 0)
     {
         ObjectNumber = objectNumber
             .CheckConstraints(num => num >= 0, Resource.PdfIndirect_ObjectNumberMustBePositive);
@@ -26,9 +26,8 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
             .CheckConstraints(num => num <= 65535, Resource.PdfIndirect_GenerationNumberMustNotExceedMaxAllowedValue);
 
         Value = pdfObject;
-        _hashCode = HashCode.Combine(nameof(PdfIndirect).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
+        _hashCode = HashCode.Combine(nameof(PdfIndirect<T>).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
         _bytes = null;
-        ReferenceIdentifier = $"{ObjectNumber} {GenerationNumber} R";
     }
 
     #endregion
@@ -39,15 +38,13 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
 
     public int ObjectNumber { get; }
 
-    public string ReferenceIdentifier { get; }
-
     public int Length => Content.Length;
 
     public ReadOnlyMemory<byte> Bytes => _bytes ??= Encoding.ASCII.GetBytes(Content);
 
     public string Content => GenerateContent();
 
-    public IPdfObject Value { get; }
+    public T Value { get; }
 
     #endregion
 
@@ -58,7 +55,7 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
         return _hashCode;
     }
 
-    public bool Equals(PdfIndirect? other)
+    public bool Equals(PdfIndirect<T>? other)
     {
         return other != null
                && ObjectNumber == other.ObjectNumber
@@ -67,7 +64,7 @@ public sealed class PdfIndirect : IPdfObject<IPdfObject>, IEquatable<PdfIndirect
 
     public override bool Equals(object? obj)
     {
-        return obj is PdfIndirect pdfName && Equals(pdfName);
+        return obj is PdfIndirect<T> pdfIndirect && Equals(pdfIndirect);
     }
 
     #endregion

--- a/src/Off.Net.Pdf.Core/Primitives/PdfIndirectIdentifier.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfIndirectIdentifier.cs
@@ -1,0 +1,74 @@
+﻿using System.Text;
+using Off.Net.Pdf.Core.Interfaces;
+
+namespace Off.Net.Pdf.Core.Primitives;
+
+public sealed class PdfIndirectIdentifier<T> : IPdfObject, IEquatable<PdfIndirectIdentifier<T>> where T: IPdfObject
+{
+    #region Fields
+
+    private readonly Lazy<int> _hashCode;
+    private readonly Lazy<string> _literalValue;
+    private readonly Lazy<byte[]> _bytes;
+
+    #endregion
+
+    #region Constructors
+
+    public PdfIndirectIdentifier(PdfIndirect<T> pdfObject)
+    {
+        _hashCode = new Lazy<int>(() => HashCode.Combine(nameof(PdfIndirectIdentifier<T>).GetHashCode(), pdfObject.ObjectNumber, pdfObject.GenerationNumber));
+        _literalValue = new Lazy<string>(GenerateContent);
+        _bytes = new Lazy<byte[]>(() => Encoding.ASCII.GetBytes(Content));
+
+        ObjectNumber = pdfObject.ObjectNumber;
+        GenerationNumber = pdfObject.GenerationNumber;
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int GenerationNumber { get; }
+
+    public int ObjectNumber { get; }
+
+
+    public int Length => Content.Length;
+
+    public ReadOnlyMemory<byte> Bytes => _bytes.Value;
+
+    public string Content => _literalValue.Value;
+
+    #endregion
+
+    #region Public Methods
+
+    public override int GetHashCode()
+    {
+        return _hashCode.Value;
+    }
+
+    public bool Equals(PdfIndirectIdentifier<T>? other)
+    {
+        return other != null
+               && ObjectNumber == other.ObjectNumber
+               && GenerationNumber == other.GenerationNumber;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is PdfIndirectIdentifier<T> pdfIndirect && Equals(pdfIndirect);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private string GenerateContent()
+    {
+        return $"{ObjectNumber} {GenerationNumber} R";
+    }
+
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/Primitives/PdfStream.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfStream.cs
@@ -18,7 +18,7 @@ public sealed class PdfStream : IPdfObject<ReadOnlyMemory<char>>, IEquatable<Pdf
     private readonly int _hashCode;
     private string _literalValue = string.Empty;
     private byte[]? _bytes;
-    private PdfDictionary? _streamExtentDictionary;
+    private PdfDictionary<IPdfObject>? _streamExtentDictionary;
 
     #endregion
 
@@ -44,7 +44,7 @@ public sealed class PdfStream : IPdfObject<ReadOnlyMemory<char>>, IEquatable<Pdf
 
     public string Content => GenerateContent();
 
-    public PdfDictionary StreamExtent => GenerateStreamExtendDictionary();
+    public PdfDictionary<IPdfObject> StreamExtent => GenerateStreamExtendDictionary();
 
     #endregion
 
@@ -91,7 +91,7 @@ public sealed class PdfStream : IPdfObject<ReadOnlyMemory<char>>, IEquatable<Pdf
         return _literalValue;
     }
 
-    private PdfDictionary GenerateStreamExtendDictionary()
+    private PdfDictionary<IPdfObject> GenerateStreamExtendDictionary()
     {
         if (_streamExtentDictionary != null)
         {

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -60,6 +60,51 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The byte offset of the file trailer object must be positive.
+        /// </summary>
+        internal static string FileTrailer_ByteOffsetMustBePositive {
+            get {
+                return ResourceManager.GetString("FileTrailer_ByteOffsetMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The encrypt key must be a non-empty collection.
+        /// </summary>
+        internal static string FileTrailer_EncryptMustHaveANonEmptyCollection {
+            get {
+                return ResourceManager.GetString("FileTrailer_EncryptMustHaveANonEmptyCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Id key must be a an array of two byte-strings.
+        /// </summary>
+        internal static string FileTrailer_IdMustBeAnArrayOfTwoByteStrings {
+            get {
+                return ResourceManager.GetString("FileTrailer_IdMustBeAnArrayOfTwoByteStrings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The prev key must be a positive number.
+        /// </summary>
+        internal static string FileTrailer_PrevMustBePositive {
+            get {
+                return ResourceManager.GetString("FileTrailer_PrevMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The size key must be a positive and non-zero value.
+        /// </summary>
+        internal static string FileTrailer_SizeMustBeGreaterThanZero {
+            get {
+                return ResourceManager.GetString("FileTrailer_SizeMustBeGreaterThanZero", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The generation number must be positive.
         /// </summary>
         internal static string PdfIndirect_GenerationNumberMustBePositive {

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -167,4 +167,19 @@
   <data name="XRefTable_MustHaveNonEmptyEntriesCollection" xml:space="preserve">
     <value>The cross-reference table must have non-empty list of sections</value>
   </data>
+  <data name="FileTrailer_ByteOffsetMustBePositive" xml:space="preserve">
+    <value>The byte offset of the file trailer object must be positive</value>
+  </data>
+  <data name="FileTrailer_SizeMustBeGreaterThanZero" xml:space="preserve">
+    <value>The size key must be a positive and non-zero value</value>
+  </data>
+  <data name="FileTrailer_PrevMustBePositive" xml:space="preserve">
+    <value>The prev key must be a positive number</value>
+  </data>
+  <data name="FileTrailer_IdMustBeAnArrayOfTwoByteStrings" xml:space="preserve">
+    <value>The Id key must be a an array of two byte-strings</value>
+  </data>
+  <data name="FileTrailer_EncryptMustHaveANonEmptyCollection" xml:space="preserve">
+    <value>The encrypt key must be a non-empty collection</value>
+  </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/FileTrailerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/FileTrailerTests.cs
@@ -1,0 +1,636 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Off.Net.Pdf.Core.FileStructure;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.FileStructure;
+
+public class FileTrailerTests
+{
+    [Theory(DisplayName = $"Constructor with negative {nameof(FileTrailer.ByteOffset)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1)]
+    [InlineData(-34)]
+    [InlineData(-124)]
+    public void FileTrailer_ConstructorWithNegativeBytesOffset_ShouldThrowException(long byteOffset)
+    {
+        // Arrange
+
+        // Act
+        FileTrailer FileTrailerFunction() => new FileTrailerOptions().ToFileTrailer(byteOffset);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(FileTrailerFunction);
+        Assert.StartsWith(Resource.FileTrailer_ByteOffsetMustBePositive, exception.Message);
+    }
+
+    [Theory(DisplayName = $"Constructor with negative {nameof(FileTrailerOptions.Size)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-34)]
+    [InlineData(-124)]
+    public void FileTrailer_ConstructorWithNegativeSize_ShouldThrowException(int size)
+    {
+        // Arrange
+
+        // Act
+        FileTrailer FileTrailerFunction() => new(123, options => options.Size = size);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(FileTrailerFunction);
+        Assert.StartsWith(Resource.FileTrailer_SizeMustBeGreaterThanZero, exception.Message);
+    }
+
+    [Theory(DisplayName = $"Constructor with negative {nameof(FileTrailerOptions.Prev)} should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1)]
+    [InlineData(-34)]
+    [InlineData(-124)]
+    public void FileTrailer_ConstructorWithNegativePrev_ShouldThrowException(int? prev)
+    {
+        // Arrange
+
+        // Act
+        FileTrailer FileTrailerFunction() => new(123, options =>
+        {
+            options.Size = 456;
+            options.Prev = prev;
+        });
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(FileTrailerFunction);
+        Assert.StartsWith(Resource.FileTrailer_PrevMustBePositive, exception.Message);
+    }
+
+    [Fact(DisplayName = $"Constructor with empty {nameof(FileTrailerOptions.Encrypt)} dictionary should throw an {nameof(ArgumentOutOfRangeException)}")]
+    public void FileTrailer_ConstructorWithEmptyEncryptDictionary_ShouldThrowException()
+    {
+        // Arrange
+        var rootDictionary = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } };
+        var encryptDictionary = new Dictionary<PdfName, IPdfObject>(1);
+
+        // Act
+        FileTrailer FileTrailerFunction() => new(123, options =>
+        {
+            options.Size = 456;
+            options.Prev = 789;
+            options.Root = rootDictionary
+                .ToPdfDictionary()
+                .ToPdfIndirect(012)
+                .ToPdfIndirectIdentifier();
+            options.Encrypt = encryptDictionary.ToPdfDictionary();
+        });
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(FileTrailerFunction);
+        Assert.StartsWith(Resource.FileTrailer_EncryptMustHaveANonEmptyCollection, exception.Message);
+    }
+
+    [Fact(DisplayName = $"Constructor with an invalid {nameof(FileTrailerOptions.Id)}, when {nameof(FileTrailerOptions.Encrypt)} is present, should throw an {nameof(ArgumentOutOfRangeException)}")]
+    public void FileTrailer_ConstructorWithInvalidIdWhenEncryptIsPresent_ShouldThrowException()
+    {
+        // Arrange
+        var rootDictionary = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } };
+        var encryptDictionary = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } };
+
+        // Act
+        FileTrailer FileTrailerFunction() => new(123, options =>
+        {
+            options.Size = 456;
+            options.Prev = 789;
+            options.Root = rootDictionary
+                .ToPdfDictionary()
+                .ToPdfIndirect(012)
+                .ToPdfIndirectIdentifier();
+            options.Encrypt = encryptDictionary.ToPdfDictionary();
+        });
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(FileTrailerFunction);
+        Assert.StartsWith(Resource.FileTrailer_IdMustBeAnArrayOfTwoByteStrings, exception.Message);
+    }
+
+    [Theory(DisplayName = $"{nameof(FileTrailer.ByteOffset)} property should return a valid value")]
+    [InlineData(123)]
+    [InlineData(456)]
+    [InlineData(789)]
+    public void FileTrailer_ByteOffset_ShouldReturnValidValue(long byteOffset)
+    {
+        // Arrange
+        var rootDictionary = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } };
+        FileTrailerOptions fileTrailerOptions = new()
+        {
+            Size = 456,
+            Prev = 789,
+            Root = rootDictionary
+                .ToPdfDictionary()
+                .ToPdfIndirect(012)
+                .ToPdfIndirectIdentifier()
+        };
+        FileTrailer fileTrailer = new(byteOffset, fileTrailerOptions);
+
+        // Act
+        long actualByteOffset = fileTrailer.ByteOffset;
+
+        // Assert
+        Assert.Equal(byteOffset, actualByteOffset);
+    }
+
+    [Fact(DisplayName = $"{nameof(FileTrailer.FileTrailerDictionary)} property should return a valid value")]
+    public void FileTrailer_FileTrailerDictionary_ShouldReturnValidValue()
+    {
+        // Arrange
+        var rootDictionary = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } };
+        FileTrailerOptions fileTrailerOptions = new()
+        {
+            Size = 456,
+            Prev = 789,
+            Root = rootDictionary
+                .ToPdfDictionary()
+                .ToPdfIndirect(012)
+                .ToPdfIndirectIdentifier()
+        };
+        FileTrailer fileTrailer = new(123, fileTrailerOptions);
+
+        // Act
+        PdfDictionary<IPdfObject> fileTrailerDictionary = fileTrailer.FileTrailerDictionary;
+
+        // Assert
+        Assert.Contains("Size", fileTrailerDictionary.Value);
+        Assert.Contains("Prev", fileTrailerDictionary.Value);
+        Assert.Contains("Root", fileTrailerDictionary.Value);
+        Assert.Equal(fileTrailerOptions.Size, fileTrailerDictionary.Value["Size"]);
+        Assert.Equal(fileTrailerOptions.Prev, fileTrailerDictionary.Value["Prev"]);
+        Assert.Equal(fileTrailerOptions.Root, fileTrailerDictionary.Value["Root"]);
+    }
+
+    [Theory(DisplayName = $"{nameof(FileTrailer.Content)} property should return a valid value")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_Content_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_Content_ShouldReturnValidValue(FileTrailer fileTrailer, string expectedContent)
+    {
+        // Arrange
+
+        // Act
+        string actualContent = fileTrailer.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+
+    [Theory(DisplayName = $"{nameof(FileTrailer.Content)} property, accessed multiple times, should return the same reference")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_NoExpectedData_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_Content_MultipleAccesses_ShouldReturnSameReference(FileTrailer fileTrailer)
+    {
+        // Arrange
+
+        // Act
+        string actualContent1 = fileTrailer.Content;
+        string actualContent2 = fileTrailer.Content;
+
+        // Assert
+        Assert.True(ReferenceEquals(actualContent1, actualContent2));
+    }
+
+    [Theory(DisplayName = $"{nameof(FileTrailer.Length)} property should return a valid value")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_Length_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_Length_ShouldReturnValidValue(FileTrailer fileTrailer, int expectedLength)
+    {
+        // Arrange
+
+        // Act
+        int actualLength = fileTrailer.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Theory(DisplayName = $"{nameof(FileTrailer.Bytes)} property should return a valid value")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_Bytes_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_Bytes_ShouldReturnValidValue(FileTrailer fileTrailer, byte[] expectedBytes)
+    {
+        // Arrange
+
+        // Act
+        byte[] actualBytes = fileTrailer.Bytes.ToArray();
+
+        // Assert
+        Assert.Equal(expectedBytes, actualBytes);
+    }
+
+    [Theory(DisplayName = "Check if GetHashCode method returns valid value")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_NoExpectedData_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void XFileTrailer_GetHashCode_CheckValidity(FileTrailer fileTrailer)
+    {
+        // Arrange
+        int expectedHashCode = HashCode.Combine(nameof(FileTrailer).GetHashCode(), fileTrailer.Content.GetHashCode());
+
+        // Act
+        int actualHashCode = fileTrailer.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Theory(DisplayName = "Check if Equals returns a valid result")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_Equals_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_Equals_CheckValidity(FileTrailer xRefEntry1, FileTrailer xRefEntry2, bool expectedValue)
+    {
+        // Arrange
+
+        // Act
+        bool actualResult = xRefEntry1.Equals(xRefEntry2);
+
+        // Assert
+        Assert.Equal(expectedValue, actualResult);
+    }
+
+    [Theory(DisplayName = "Check if Equals method with null object returns always false")]
+    [MemberData(nameof(FileTrailerTestsDataGenerator.FileTrailer_NoExpectedData_TestCases), MemberType = typeof(FileTrailerTestsDataGenerator))]
+    public void FileTrailer_EqualsNullObject_CheckValidity(FileTrailer xRefEntry)
+    {
+        // Arrange
+
+        // Act
+        bool actualResult1 = xRefEntry.Equals(null);
+
+        Debug.Assert(xRefEntry != null, nameof(xRefEntry) + " != null");
+        bool actualResult2 = xRefEntry.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult1);
+        Assert.False(actualResult2);
+    }
+}
+
+internal static class FileTrailerTestsDataGenerator
+{
+    public static IEnumerable<object[]> FileTrailer_Content_TestCases()
+    {
+        yield return new object[]
+        {
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            "trailer\n<</Size 22 /Root 2 0 R /Info 1 0 R /ID [<81b14aafa313db63dbd6f981e49f94f4> <81b14aafa313db63dbd6f981e49f94f4>]>>\nstartxref\n18799\n%%EOF"
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            "trailer\n<</Size 22 /Prev 196 /Root 2 0 R /Info 1 0 R /ID [<81b14aafa313db63dbd6f981e49f94f4> <81b14aafa313db63dbd6f981e49f94f4>]>>\nstartxref\n12345\n%%EOF"
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            "trailer\n<</Size 22 /Prev 196 /Root 2 0 R /Encrypt <</Test1 1 /Test2 2>> /Info 1 0 R /ID [<81b14aafa313db63dbd6f981e49f94f4> <81b14aafa313db63dbd6f981e49f94f4>]>>\nstartxref\n12345\n%%EOF"
+        };
+    }
+
+    public static IEnumerable<object[]> FileTrailer_Length_TestCases()
+    {
+        yield return new object[]
+        {
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            142
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            152
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            183
+        };
+    }
+
+    public static IEnumerable<object[]> FileTrailer_Bytes_TestCases()
+    {
+        yield return new object[]
+        {
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new byte[]
+            {
+                0x74, 0x72, 0x61, 0x69, 0x6C, 0x65, 0x72, 0x0A, 0x3C, 0x3C, 0x2F, 0x53, 0x69, 0x7A, 0x65, 0x20, 0x32, 0x32, 0x20, 0x2F, 0x52, 0x6F, 0x6F, 0x74, 0x20, 0x32, 0x20, 0x30, 0x20, 0x52,
+                0x20, 0x2F, 0x49, 0x6E, 0x66, 0x6F, 0x20, 0x31, 0x20, 0x30, 0x20, 0x52, 0x20, 0x2F, 0x49, 0x44, 0x20, 0x5B, 0x3C, 0x38, 0x31, 0x62, 0x31, 0x34, 0x61, 0x61, 0x66, 0x61, 0x33, 0x31,
+                0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65, 0x34, 0x39, 0x66, 0x39, 0x34, 0x66, 0x34, 0x3E, 0x20, 0x3C, 0x38, 0x31, 0x62, 0x31, 0x34, 0x61,
+                0x61, 0x66, 0x61, 0x33, 0x31, 0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65, 0x34, 0x39, 0x66, 0x39, 0x34, 0x66, 0x34, 0x3E, 0x5D, 0x3E, 0x3E,
+                0x0A, 0x73, 0x74, 0x61, 0x72, 0x74, 0x78, 0x72, 0x65, 0x66, 0x0A, 0x31, 0x38, 0x37, 0x39, 0x39, 0x0A, 0x25, 0x25, 0x45, 0x4F, 0x46
+            }
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new byte[]
+            {
+                0x74, 0x72, 0x61, 0x69, 0x6C, 0x65, 0x72, 0x0A, 0x3C, 0x3C, 0x2F, 0x53, 0x69, 0x7A, 0x65, 0x20, 0x32, 0x32, 0x20, 0x2F, 0x50, 0x72, 0x65, 0x76, 0x20, 0x31, 0x39, 0x36, 0x20, 0x2F,
+                0x52, 0x6F, 0x6F, 0x74, 0x20, 0x32, 0x20, 0x30, 0x20, 0x52, 0x20, 0x2F, 0x49, 0x6E, 0x66, 0x6F, 0x20, 0x31, 0x20, 0x30, 0x20, 0x52, 0x20, 0x2F, 0x49, 0x44, 0x20, 0x5B, 0x3C, 0x38,
+                0x31, 0x62, 0x31, 0x34, 0x61, 0x61, 0x66, 0x61, 0x33, 0x31, 0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65, 0x34, 0x39, 0x66, 0x39, 0x34, 0x66,
+                0x34, 0x3E, 0x20, 0x3C, 0x38, 0x31, 0x62, 0x31, 0x34, 0x61, 0x61, 0x66, 0x61, 0x33, 0x31, 0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65, 0x34,
+                0x39, 0x66, 0x39, 0x34, 0x66, 0x34, 0x3E, 0x5D, 0x3E, 0x3E, 0x0A, 0x73, 0x74, 0x61, 0x72, 0x74, 0x78, 0x72, 0x65, 0x66, 0x0A, 0x31, 0x32, 0x33, 0x34, 0x35, 0x0A, 0x25, 0x25, 0x45,
+                0x4F, 0x46
+            }
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new byte[]
+            {
+                0x74, 0x72, 0x61, 0x69, 0x6C, 0x65, 0x72, 0x0A, 0x3C, 0x3C, 0x2F, 0x53, 0x69, 0x7A, 0x65, 0x20, 0x32, 0x32, 0x20, 0x2F, 0x50, 0x72, 0x65, 0x76, 0x20, 0x31, 0x39, 0x36, 0x20, 0x2F,
+                0x52, 0x6F, 0x6F, 0x74, 0x20, 0x32, 0x20, 0x30, 0x20, 0x52, 0x20, 0x2F, 0x45, 0x6E, 0x63, 0x72, 0x79, 0x70, 0x74, 0x20, 0x3C, 0x3C, 0x2F, 0x54, 0x65, 0x73, 0x74, 0x31, 0x20, 0x31,
+                0x20, 0x2F, 0x54, 0x65, 0x73, 0x74, 0x32, 0x20, 0x32, 0x3E, 0x3E, 0x20, 0x2F, 0x49, 0x6E, 0x66, 0x6F, 0x20, 0x31, 0x20, 0x30, 0x20, 0x52, 0x20, 0x2F, 0x49, 0x44, 0x20, 0x5B, 0x3C,
+                0x38, 0x31, 0x62, 0x31, 0x34, 0x61, 0x61, 0x66, 0x61, 0x33, 0x31, 0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65, 0x34, 0x39, 0x66, 0x39, 0x34,
+                0x66, 0x34, 0x3E, 0x20, 0x3C, 0x38, 0x31, 0x62, 0x31, 0x34, 0x61, 0x61, 0x66, 0x61, 0x33, 0x31, 0x33, 0x64, 0x62, 0x36, 0x33, 0x64, 0x62, 0x64, 0x36, 0x66, 0x39, 0x38, 0x31, 0x65,
+                0x34, 0x39, 0x66, 0x39, 0x34, 0x66, 0x34, 0x3E, 0x5D, 0x3E, 0x3E, 0x0A, 0x73, 0x74, 0x61, 0x72, 0x74, 0x78, 0x72, 0x65, 0x66, 0x0A, 0x31, 0x32, 0x33, 0x34, 0x35, 0x0A, 0x25, 0x25,
+                0x45, 0x4F, 0x46
+            }
+        };
+    }
+
+    public static IEnumerable<object[]> FileTrailer_NoExpectedData_TestCases()
+    {
+        yield return new object[]
+        {
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            })
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            })
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            })
+        };
+    }
+
+    public static IEnumerable<object[]> FileTrailer_Equals_TestCases()
+    {
+        yield return new object[]
+        {
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new FileTrailer(18799, options =>
+            {
+                options.Size = 22;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            true
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 1;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = 196;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            false
+        };
+
+        yield return new object[]
+        {
+            new FileTrailer(12345, options =>
+            {
+                options.Size = 22;
+                options.Prev = null;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            new FileTrailer(0, options =>
+            {
+                options.Size = 22;
+                options.Prev = 0;
+                options.Root = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(2)
+                    .ToPdfIndirectIdentifier();
+                options.Encrypt = new Dictionary<PdfName, IPdfObject>(2) { { "Test1", new PdfInteger(1) }, { "Test2", new PdfInteger(2) } }
+                    .ToPdfDictionary();
+                options.Info = new Dictionary<PdfName, IPdfObject>(1) { { "Test", new PdfInteger(1) } }
+                    .ToPdfDictionary()
+                    .ToPdfIndirect(1)
+                    .ToPdfIndirectIdentifier();
+                options.Id = new[] { new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true), new PdfString("81b14aafa313db63dbd6f981e49f94f4", isHexString: true) }.ToPdfArray();
+            }),
+            false
+        };
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
@@ -13,7 +13,7 @@ public class PdfArrayTests
     public void PdfArray_ParameterizedConstructor_CheckValue(List<IPdfObject> inputValue)
     {
         // Arrange
-        PdfArray pdfArray = PdfArray.CreateRange(inputValue); // Use the CreateRange static method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray = PdfArray<IPdfObject>.CreateRange(inputValue); // Use the CreateRange static method to initialize an PdfArray instance
 
         // Act
 
@@ -26,7 +26,7 @@ public class PdfArrayTests
     public void PdfArray_Length_CheckValue(IEnumerable<IPdfObject> inputValue, int expectedLength)
     {
         // Arrange
-        PdfArray pdfArray = inputValue.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray = inputValue.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         int actualLength = pdfArray.Length;
@@ -39,7 +39,7 @@ public class PdfArrayTests
     public void PdfArray_Equals_NullArgument_ShouldReturnFalse()
     {
         // Arrange
-        PdfArray pdfArray1 = new PdfName("Name1").ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<PdfName> pdfArray1 = new PdfName("Name1").ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         bool actualResult = pdfArray1.Equals(null);
@@ -52,7 +52,7 @@ public class PdfArrayTests
     public void PdfArray_Equals2_NullArgument_ShouldReturnFalse()
     {
         // Arrange
-        PdfArray pdfArray1 = PdfArray.Create(new PdfString("901FA", true)); // Use the Create static method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray1 = PdfArray<IPdfObject>.Create(new PdfString("901FA", true)); // Use the Create static method to initialize an PdfArray instance
 
         // Act
         bool actualResult = pdfArray1.Equals((object?)null);
@@ -66,8 +66,8 @@ public class PdfArrayTests
     {
         // Arrange
         IReadOnlyCollection<IPdfObject> objects1 = new List<IPdfObject> { new PdfInteger(-65), new PdfName("#ABC") };
-        PdfArray pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
-        PdfArray pdfArray2 = pdfArray1; // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray2 = pdfArray1; // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         bool actualResult = pdfArray1.Equals((object)pdfArray2);
@@ -81,8 +81,8 @@ public class PdfArrayTests
     {
         // Arrange
         IReadOnlyCollection<IPdfObject> objects1 = new List<IPdfObject> { new PdfInteger(-65), new PdfName("#ABC") };
-        PdfArray pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
-        PdfArray pdfArray2 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray1 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray2 = objects1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         bool actualResult = pdfArray1.Equals((object)pdfArray2);
@@ -96,7 +96,7 @@ public class PdfArrayTests
     public void PdfArray_Bytes_CheckValidity(IReadOnlyCollection<IPdfObject> value1, byte[] expectedBytes)
     {
         // Arrange
-        PdfArray pdfArray1 = value1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray1 = value1.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         ReadOnlyMemory<byte> actualBytes = pdfArray1.Bytes;
@@ -110,8 +110,8 @@ public class PdfArrayTests
     public void PdfArray_GetHashCode_CheckValidity(IReadOnlyCollection<IPdfObject> value1)
     {
         // Arrange
-        PdfArray pdfArray1 = new(value1);
-        int expectedHashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value1.GetHashCode());
+        PdfArray<IPdfObject> pdfArray1 = new(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfArray<IPdfObject>).GetHashCode(), value1.GetHashCode());
 
         // Act
         int actualHashCode = pdfArray1.GetHashCode();
@@ -132,9 +132,9 @@ public class PdfArrayTests
             new PdfString("Ralph"),
             new PdfName("SomeName")
         };
-        PdfArray pdfArray1 = new(value1);
-        PdfArray pdfArray2 = new(value1);
-        int expectedHashCode = HashCode.Combine(nameof(PdfArray).GetHashCode(), value1.GetHashCode());
+        PdfArray<IPdfObject> pdfArray1 = new(value1);
+        PdfArray<IPdfObject> pdfArray2 = new(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfArray<IPdfObject>).GetHashCode(), value1.GetHashCode());
 
         // Act
         int actualHashCode1 = pdfArray1.GetHashCode();
@@ -167,8 +167,8 @@ public class PdfArrayTests
             new PdfString("Ralph"),
             new PdfName("SomeName")
         };
-        PdfArray pdfArray1 = new(value1);
-        PdfArray pdfArray2 = new(value2);
+        PdfArray<IPdfObject> pdfArray1 = new(value1);
+        PdfArray<IPdfObject> pdfArray2 = new(value2);
 
         // Act
         int actualHashCode1 = pdfArray1.GetHashCode();
@@ -183,7 +183,7 @@ public class PdfArrayTests
     public void PdfArray_Value_Count_ShouldReturn1()
     {
         // Arrange
-        PdfArray pdfArray1 = PdfArray.Create(new PdfInteger(549));
+        PdfArray<IPdfObject> pdfArray1 = PdfArray<IPdfObject>.Create(new PdfInteger(549));
 
         // Act
         int actualValueCount = pdfArray1.Value.Count;
@@ -197,7 +197,7 @@ public class PdfArrayTests
     public void PdfArray_Content_Check(IReadOnlyCollection<IPdfObject> inputValues, string expectedContentValue)
     {
         // Arrange
-        PdfArray pdfArray1 = inputValues.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
+        PdfArray<IPdfObject> pdfArray1 = inputValues.ToPdfArray(); // Use the ToPdfArray extension method to initialize an PdfArray instance
 
         // Act
         string actualContentValue = pdfArray1.Content;
@@ -230,7 +230,7 @@ internal static class PdfArrayTestDataGenerator
             },
             34
         };
-        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, 13 };
+        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray<IPdfObject>(new List<IPdfObject> { new PdfNull() }) }, 13 };
     }
 
     public static IEnumerable<object[]> PdfArray_Bytes_TestCases()
@@ -249,7 +249,7 @@ internal static class PdfArrayTestDataGenerator
         };
         yield return new object[]
         {
-            new List<IPdfObject> { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, new byte[] { 91, 116, 114, 117, 101, 32, 91, 110, 117, 108, 108, 93, 93 }
+            new List<IPdfObject> { new PdfBoolean(true), new PdfArray<IPdfObject>(new List<IPdfObject> { new PdfNull() }) }, new byte[] { 91, 116, 114, 117, 101, 32, 91, 110, 117, 108, 108, 93, 93 }
         };
     }
 
@@ -266,7 +266,7 @@ internal static class PdfArrayTestDataGenerator
                 new PdfName("SomeName")
             }
         };
-        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) } };
+        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray<IPdfObject>(new List<IPdfObject> { new PdfNull() }) } };
     }
 
     public static IEnumerable<object[]> PdfArray_Content_TestCases()
@@ -283,7 +283,7 @@ internal static class PdfArrayTestDataGenerator
             },
             "[549 3.14 false (Ralph) /SomeName]"
         };
-        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray(new List<IPdfObject> { new PdfNull() }) }, "[true [null]]" };
+        yield return new object[] { new List<IPdfObject> { new PdfBoolean(true), new PdfArray<IPdfObject>(new List<IPdfObject> { new PdfNull() }) }, "[true [null]]" };
         yield return new object[] { new List<IPdfObject>(0), "[]" };
     }
 }

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
@@ -13,7 +13,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_ParameterizedConstructor_CheckValue(Dictionary<PdfName, IPdfObject> inputValue)
     {
         // Arrange
-        PdfDictionary pdfDictionary = PdfDictionary.CreateRange(inputValue); // Use the CreateRange static method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary = PdfDictionary<IPdfObject>.CreateRange(inputValue); // Use the CreateRange static method to initialize an PdfDictionary instance
 
         // Act
 
@@ -26,7 +26,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Length_CheckValue(Dictionary<PdfName, IPdfObject> inputValue, int expectedLength)
     {
         // Arrange
-        PdfDictionary pdfDictionary = inputValue.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary = inputValue.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
         int actualLength = pdfDictionary.Length;
@@ -39,7 +39,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Equals_NullArgument_ShouldReturnFalse()
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = new KeyValuePair<PdfName, IPdfObject>(new PdfName("Name1"), new PdfBoolean()).ToPdfDictionary();
+        PdfDictionary<IPdfObject> pdfDictionary1 = new KeyValuePair<PdfName, IPdfObject>(new PdfName("Name1"), new PdfBoolean()).ToPdfDictionary();
 
         // Act
         bool actualResult = pdfDictionary1.Equals(null);
@@ -52,7 +52,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Equals2_NullArgument_ShouldReturnFalse()
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = PdfDictionary.Create(new KeyValuePair<PdfName, IPdfObject>(new PdfName("Name1"), new PdfString("Value1")));
+        PdfDictionary<IPdfObject> pdfDictionary1 = PdfDictionary<IPdfObject>.Create(new KeyValuePair<PdfName, IPdfObject>(new PdfName("Name1"), new PdfString("Value1")));
 
         // Act
         bool actualResult = pdfDictionary1.Equals((object?)null);
@@ -66,8 +66,8 @@ public class PdfDictionaryTests
     {
         // Arrange
         Dictionary<PdfName, IPdfObject> objects1 = new() { { new PdfName("Name1"), new PdfNull() } };
-        PdfDictionary pdfDictionary1 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
-        PdfDictionary pdfDictionary2 = pdfDictionary1; // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary1 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary2 = pdfDictionary1; // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
         bool actualResult = pdfDictionary1.Equals((object)pdfDictionary2);
@@ -81,8 +81,8 @@ public class PdfDictionaryTests
     {
         // Arrange
         Dictionary<PdfName, IPdfObject> objects1 = new() { { new PdfName("Name1"), new PdfNull() } };
-        PdfDictionary pdfDictionary1 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
-        PdfDictionary pdfDictionary2 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary1 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary2 = objects1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
         bool actualResult = pdfDictionary1.Equals((object)pdfDictionary2);
@@ -96,7 +96,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Bytes_CheckValidity(Dictionary<PdfName, IPdfObject> value1, byte[] expectedBytes)
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = value1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary1 = value1.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
          ReadOnlyMemory<byte> actualBytes = pdfDictionary1.Bytes;
@@ -110,8 +110,8 @@ public class PdfDictionaryTests
     public void PdfDictionary_GetHashCode_CheckValidity(IReadOnlyDictionary<PdfName, IPdfObject> value1)
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = new(value1);
-        int expectedHashCode = HashCode.Combine(nameof(PdfDictionary).GetHashCode(), value1.GetHashCode());
+        PdfDictionary<IPdfObject> pdfDictionary1 = new(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfDictionary<IPdfObject>).GetHashCode(), value1.GetHashCode());
 
         // Act
         int actualHashCode = pdfDictionary1.GetHashCode();
@@ -125,9 +125,9 @@ public class PdfDictionaryTests
     {
         // Arrange
         Dictionary<PdfName, IPdfObject> value1 = new() { { new PdfName("Type"), new PdfName("Example") }, { new PdfName("SubType"), new PdfName("DictionaryExample") } };
-        PdfDictionary pdfDictionary1 = new(value1);
-        PdfDictionary pdfDictionary2 = new(value1);
-        int expectedHashCode = HashCode.Combine(nameof(PdfDictionary).GetHashCode(), value1.GetHashCode());
+        PdfDictionary<IPdfObject> pdfDictionary1 = new(value1);
+        PdfDictionary<IPdfObject> pdfDictionary2 = new(value1);
+        int expectedHashCode = HashCode.Combine(nameof(PdfDictionary<IPdfObject>).GetHashCode(), value1.GetHashCode());
 
         // Act
         int actualHashCode1 = pdfDictionary1.GetHashCode();
@@ -146,8 +146,8 @@ public class PdfDictionaryTests
         // Arrange
         Dictionary<PdfName, IPdfObject> value1 = new() { { new PdfName("Type"), new PdfName("Example") }, { new PdfName("SubType"), new PdfName("DictionaryExample") } };
         Dictionary<PdfName, IPdfObject> value2 = new() { { new PdfName("Type"), new PdfName("Example") }, { new PdfName("SubType"), new PdfName("DictionaryExample") } };
-        PdfDictionary pdfDictionary1 = new(value1);
-        PdfDictionary pdfDictionary2 = new(value2);
+        PdfDictionary<IPdfObject> pdfDictionary1 = new(value1);
+        PdfDictionary<IPdfObject> pdfDictionary2 = new(value2);
 
         // Act
         int actualHashCode1 = pdfDictionary1.GetHashCode();
@@ -162,7 +162,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Value_Count_ShouldReturn1()
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = PdfDictionary.Create(new KeyValuePair<PdfName, IPdfObject>(new PdfName("Type"), new PdfName("Example")));
+        PdfDictionary<IPdfObject> pdfDictionary1 = PdfDictionary<IPdfObject>.Create(new KeyValuePair<PdfName, IPdfObject>(new PdfName("Type"), new PdfName("Example")));
 
         // Act
         int actualValueCount = pdfDictionary1.Value.Count;
@@ -176,7 +176,7 @@ public class PdfDictionaryTests
     public void PdfDictionary_Content_Check(Dictionary<PdfName, IPdfObject> inputValues, string expectedContentValue)
     {
         // Arrange
-        PdfDictionary pdfDictionary1 = inputValues.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
+        PdfDictionary<IPdfObject> pdfDictionary1 = inputValues.ToPdfDictionary(); // Use the ToPdfDictionary extension method to initialize an PdfDictionary instance
 
         // Act
         string actualContentValue = pdfDictionary1.Content;
@@ -208,7 +208,7 @@ internal static class PdfDictionaryTestDataGenerator
                 { new PdfName("StringItem"), new PdfString("a string") },
                 {
                     new PdfName("Subdictionary"),
-                    PdfDictionary.CreateRange(new Dictionary<PdfName, IPdfObject>
+                    PdfDictionary<IPdfObject>.CreateRange(new Dictionary<PdfName, IPdfObject>
                     {
                         { new PdfName("Item1"), new PdfReal(0.4f) },
                         { new PdfName("Item2"), new PdfBoolean(true) },
@@ -235,7 +235,7 @@ internal static class PdfDictionaryTestDataGenerator
                 { new PdfName("StringItem"), new PdfString("a string") },
                 {
                     new PdfName("Subdictionary"),
-                    PdfDictionary.CreateRange(new Dictionary<PdfName, IPdfObject>
+                    PdfDictionary<IPdfObject>.CreateRange(new Dictionary<PdfName, IPdfObject>
                     {
                         { new PdfName("Item1"), new PdfReal(0.4f) },
                         { new PdfName("Item2"), new PdfBoolean(true) },
@@ -277,7 +277,7 @@ internal static class PdfDictionaryTestDataGenerator
                 { new PdfName("IntegerItem"), new PdfInteger(12) },
                 {
                     new PdfName("Subdictionary"),
-                    PdfDictionary.CreateRange(new Dictionary<PdfName, IPdfObject>
+                    PdfDictionary<IPdfObject>.CreateRange(new Dictionary<PdfName, IPdfObject>
                     {
                         { new PdfName("Item1"), new PdfReal(0.4f) },
                         { new PdfName("Item2"), new PdfBoolean(true) },
@@ -308,7 +308,7 @@ internal static class PdfDictionaryTestDataGenerator
                 { new PdfName("StringItem"), new PdfString("a string") },
                 {
                     new PdfName("Subdictionary"),
-                    PdfDictionary.CreateRange(new Dictionary<PdfName, IPdfObject>
+                    PdfDictionary<IPdfObject>.CreateRange(new Dictionary<PdfName, IPdfObject>
                     {
                         { new PdfName("Item1"), new PdfReal(0.4f) },
                         { new PdfName("Item2"), new PdfBoolean(true) },

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectIdentifierTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectIdentifierTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using Off.Net.Pdf.Core.Primitives;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Primitives;
+
+public class PdfIndirectIdentifierTests
+{
+    [Theory(DisplayName = "Check Length property")]
+    [InlineData(0, 0, 5)]
+    [InlineData(12, 0,  6)]
+    [InlineData(21, 6, 6)]
+    public void PdfIndirectIdentifier_Length_CheckValue(int objectNumber, int generationNumber, int expectedLength)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString("Test").ToPdfIndirect(objectNumber, generationNumber).ToPdfIndirectIdentifier();
+
+        // Act
+        int actualLength = pdfIndirect.Length;
+
+        // Assert
+        Assert.Equal(expectedLength, actualLength);
+    }
+
+    [Theory(DisplayName = "Check Content property")]
+    [InlineData(0, 0, "Test", "0 0 R")]
+    [InlineData(12, 0, "Brillig", "12 0 R")]
+    [InlineData(21, 6, "String1", "21 6 R")]
+    public void PdfIndirectIdentifier_Content_CheckValue(int objectNumber, int generationNumber, string actualStringValue, string expectedContent)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber).ToPdfIndirectIdentifier();
+
+        // Act
+        string actualContent = pdfIndirect.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+
+    [Theory(DisplayName = "Check GetHashCode method")]
+    [InlineData(0, 0, "Test")]
+    [InlineData(12, 0, "Brillig")]
+    [InlineData(21, 6, "String1")]
+    public void PdfIndirectIdentifier_GetHashCode_CheckValidity(int objectNumber, int generationNumber, string actualStringValue)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber).ToPdfIndirectIdentifier();
+        int expectedHashCode = HashCode.Combine(nameof(PdfIndirectIdentifier<PdfString>).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
+
+        // Act
+        int actualHashCode = pdfIndirect.GetHashCode();
+
+        // Assert
+        Assert.Equal(expectedHashCode, actualHashCode);
+    }
+
+    [Fact(DisplayName = "Check Equals method")]
+    public void PdfIndirectIdentifier_Equals_Null_ShouldReturnFalse()
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString("Test").ToPdfIndirect(0).ToPdfIndirectIdentifier();
+
+        // Act
+        bool actualResult1 = pdfIndirect.Equals(null);
+        bool actualResult2 = pdfIndirect!.Equals((object?)null);
+
+        // Assert
+        Assert.False(actualResult1);
+        Assert.False(actualResult2);
+    }
+
+    [Theory(DisplayName = "Check Equals method")]
+    [InlineData(0, 0, 0, 0, "Test1", "Test2", true)] // Indirect object equality is checked against object and generation number
+    [InlineData(0, 0, 0, 0, "Test1", "Test1", true)]
+    [InlineData(0, 1, 0, 0, "Test1", "Test1", false)]
+    [InlineData(1, 1, 0, 0, "Test1", "Test1", true)]
+    [InlineData(1, 1, 1, 0, "Test1", "Test1", false)]
+    [InlineData(1, 1, 1, 1, "Test1", "Test1", true)]
+    public void PdfIndirectIdentifier_Equals_ShouldReturnFalse(int objectNumber1, int objectNumber2, int generationNumber1, int generationNumber2, string actualStringValue1, string actualStringValue2,
+        bool expectedResult)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect1 = new PdfString(actualStringValue1).ToPdfIndirect(objectNumber1, generationNumber1).ToPdfIndirectIdentifier();
+        PdfIndirectIdentifier<PdfString> pdfIndirect2 = new PdfString(actualStringValue2).ToPdfIndirect(objectNumber2, generationNumber2).ToPdfIndirectIdentifier();
+
+        // Act
+        bool actualResult = pdfIndirect1.Equals(pdfIndirect2);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory(DisplayName = "Check Equals method")]
+    [InlineData(0, 0, 0, 0, "Test1", "Test2", true)] // Indirect object equality is checked against object and generation number
+    [InlineData(0, 0, 0, 0, "Test1", "Test1", true)]
+    [InlineData(0, 1, 0, 0, "Test1", "Test1", false)]
+    [InlineData(1, 1, 0, 0, "Test1", "Test1", true)]
+    [InlineData(1, 1, 1, 0, "Test1", "Test1", false)]
+    [InlineData(1, 1, 1, 1, "Test1", "Test1", true)]
+    public void PdfIndirectIdentifier_Equals2_ShouldReturnFalse(int objectNumber1, int objectNumber2, int generationNumber1, int generationNumber2, string actualStringValue1, string actualStringValue2,
+        bool expectedResult)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect1 = new PdfString(actualStringValue1).ToPdfIndirect(objectNumber1, generationNumber1).ToPdfIndirectIdentifier();
+        PdfIndirectIdentifier<PdfString> pdfIndirect2 = new PdfString(actualStringValue2).ToPdfIndirect(objectNumber2, generationNumber2).ToPdfIndirectIdentifier();
+
+        // Act
+        bool actualResult = pdfIndirect1.Equals((object)pdfIndirect2);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory(DisplayName = "Check multiple Value access")]
+    [InlineData(0, 0, "Test")]
+    [InlineData(12, 0, "Brillig")]
+    [InlineData(21, 6, "String1")]
+    public void PdfIndirectIdentifier_Value_CheckValidity(int objectNumber, int generationNumber, string actualStringValue)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber).ToPdfIndirectIdentifier();
+
+        // Act
+        string actualContent1 = pdfIndirect.Content;
+        string actualContent2 = pdfIndirect.Content;
+
+        // Assert
+        Assert.Equal(actualContent1, actualContent2);
+        Assert.True(ReferenceEquals(actualContent1, actualContent2));
+    }
+
+    [Theory(DisplayName = "Check Bytes property")]
+    [InlineData(0, 0,  new byte[] { 0x30,0x20,0x30,0x20,0x52 })]
+    [InlineData(12, 0,  new byte[] { 0x31, 0x32, 0x20, 0x30, 0x20, 0x52 })]
+    [InlineData(21, 6,  new byte[] { 0x32, 0x31, 0x20, 0x36, 0x20, 0x52 })]
+    public void PdfIndirectIdentifier_Bytes_CheckValue(int objectNumber, int generationNumber, byte[] expectedBytes)
+    {
+        // Arrange
+        PdfIndirectIdentifier<PdfString> pdfIndirect = new PdfString("Test").ToPdfIndirect(objectNumber, generationNumber).ToPdfIndirectIdentifier();
+
+        // Act
+         ReadOnlyMemory<byte> actualBytes = pdfIndirect.Bytes;
+
+        // Assert
+        Assert.True(actualBytes.Span.SequenceEqual(expectedBytes));
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
@@ -6,24 +6,6 @@ namespace Off.Net.Pdf.Core.Tests.Primitives;
 
 public class PdfIndirectTests
 {
-    [Theory(DisplayName = "Constructor initializer check reference identifier")]
-    [InlineData(0, 0, "0 0 R")]
-    [InlineData(0, 65535, "0 65535 R")]
-    [InlineData(21, 6, "21 6 R")]
-    public void PdfIndirect_Constructor_CheckReferenceIdentifier(int objectNumber, int generationNumber, string expectedReferenceIdentifier)
-    {
-        // Arrange
-        PdfIndirect pdfIndirect = new PdfString("Test").ToPdfIndirect(objectNumber, generationNumber);
-
-        // Act
-        string actualReferenceIdentifier = pdfIndirect.ReferenceIdentifier;
-
-        // Assert
-        Assert.Equal(expectedReferenceIdentifier, actualReferenceIdentifier);
-        Assert.Equal(objectNumber, pdfIndirect.ObjectNumber);
-        Assert.Equal(generationNumber, pdfIndirect.GenerationNumber);
-    }
-
     [Theory(DisplayName = "Check Length property")]
     [InlineData(0, 0, "Test", 21)]
     [InlineData(12, 0, "Brillig", 25)]
@@ -31,7 +13,7 @@ public class PdfIndirectTests
     public void PdfIndirect_Length_CheckValue(int objectNumber, int generationNumber, string actualStringValue, int expectedLength)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
         int actualLength = pdfIndirect.Length;
@@ -47,7 +29,7 @@ public class PdfIndirectTests
     public void PdfIndirect_Content_CheckValue(int objectNumber, int generationNumber, string actualStringValue, string expectedContent)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
         string actualContent = pdfIndirect.Content;
@@ -63,7 +45,7 @@ public class PdfIndirectTests
     public void PdfIndirect_ValueString_CheckContent(int objectNumber, int generationNumber, string actualStringValue, string expectedValueContent)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
         string actualValueContent = pdfIndirect.Value.Content;
@@ -79,8 +61,8 @@ public class PdfIndirectTests
     public void PdfIndirect_GetHashCode_CheckValidity(int objectNumber, int generationNumber, string actualStringValue)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
-        int expectedHashCode = HashCode.Combine(nameof(PdfIndirect).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        int expectedHashCode = HashCode.Combine(nameof(PdfIndirect<PdfString>).GetHashCode(), objectNumber.GetHashCode(), generationNumber.GetHashCode());
 
         // Act
         int actualHashCode = pdfIndirect.GetHashCode();
@@ -93,7 +75,7 @@ public class PdfIndirectTests
     public void PdfIndirect_Equals_Null_ShouldReturnFalse()
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString("Test").ToPdfIndirect(0);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString("Test").ToPdfIndirect(0);
 
         // Act
         bool actualResult1 = pdfIndirect.Equals(null);
@@ -115,8 +97,8 @@ public class PdfIndirectTests
         bool expectedResult)
     {
         // Arrange
-        PdfIndirect pdfIndirect1 = new PdfString(actualStringValue1).ToPdfIndirect(objectNumber1, generationNumber1);
-        PdfIndirect pdfIndirect2 = new PdfString(actualStringValue2).ToPdfIndirect(objectNumber2, generationNumber2);
+        PdfIndirect<PdfString> pdfIndirect1 = new PdfString(actualStringValue1).ToPdfIndirect(objectNumber1, generationNumber1);
+        PdfIndirect<PdfString> pdfIndirect2 = new PdfString(actualStringValue2).ToPdfIndirect(objectNumber2, generationNumber2);
 
         // Act
         bool actualResult = pdfIndirect1.Equals(pdfIndirect2);
@@ -132,7 +114,7 @@ public class PdfIndirectTests
     public void PdfIndirect_Value_CheckValidity(int objectNumber, int generationNumber, string actualStringValue)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
         string actualContent1 = pdfIndirect.Content;
@@ -150,7 +132,7 @@ public class PdfIndirectTests
     public void PdfIndirect_Bytes_CheckValue(int objectNumber, int generationNumber, string actualStringValue, byte[] expectedBytes)
     {
         // Arrange
-        PdfIndirect pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
+        PdfIndirect<PdfString> pdfIndirect = new PdfString(actualStringValue).ToPdfIndirect(objectNumber, generationNumber);
 
         // Act
          ReadOnlyMemory<byte> actualBytes = pdfIndirect.Bytes;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
@@ -19,7 +19,7 @@ public class PdfStreamTests
         const string expectedKeyName = "Length";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         string? actualKeyName = actualStreamExtent.Value.Select(x => x.Key.Value).FirstOrDefault();
 
         // Assert
@@ -48,7 +48,7 @@ public class PdfStreamTests
         const string expectedOptionKeyName = "Filter";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -81,7 +81,7 @@ public class PdfStreamTests
         const string expectedOptionKeyName = "FFilter";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -102,14 +102,14 @@ public class PdfStreamTests
     {
         // Arrange
         IEnumerable<PdfName> pdfNames = filterNames.Select(filterName => new PdfName(filterName));
-        PdfArray pdfOptionNames = pdfNames.ToPdfArray();
+        PdfArray<PdfName> pdfOptionNames = pdfNames.ToPdfArray();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.Filter = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "Filter";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -117,7 +117,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfArray actualPdfArray = Assert.IsType<PdfArray>(optionValue);
+        PdfArray<PdfName> actualPdfArray = Assert.IsType<PdfArray<PdfName>>(optionValue);
         Assert.Equal(filterNames.Length, actualPdfArray.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfArray.Value);
     }
@@ -131,14 +131,14 @@ public class PdfStreamTests
     {
         // Arrange
         IEnumerable<PdfName> pdfNames = fileFilterNames.Select(filterName => new PdfName(filterName));
-        PdfArray pdfOptionNames = pdfNames.ToPdfArray();
+        PdfArray<PdfName> pdfOptionNames = pdfNames.ToPdfArray();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.FileFilter = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "FFilter";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -146,7 +146,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfArray actualPdfArray = Assert.IsType<PdfArray>(optionValue);
+        PdfArray<PdfName> actualPdfArray = Assert.IsType<PdfArray<PdfName>>(optionValue);
         Assert.Equal(fileFilterNames.Length, actualPdfArray.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfArray.Value);
     }
@@ -158,14 +158,14 @@ public class PdfStreamTests
     {
         // Arrange
         IEnumerable<PdfName> pdfNames = decodeParameters.Select(filterName => new PdfName(filterName));
-        PdfArray pdfOptionNames = pdfNames.ToPdfArray();
+        PdfArray<PdfName> pdfOptionNames = pdfNames.ToPdfArray();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.DecodeParameters = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "DecodeParms";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -173,7 +173,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfArray actualPdfArray = Assert.IsType<PdfArray>(optionValue);
+        PdfArray<PdfName> actualPdfArray = Assert.IsType<PdfArray<PdfName>>(optionValue);
         Assert.Equal(decodeParameters.Length, actualPdfArray.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfArray.Value);
     }
@@ -185,14 +185,14 @@ public class PdfStreamTests
     {
         // Arrange
         IEnumerable<PdfName> pdfNames = decodeParameters.Select(filterName => new PdfName(filterName));
-        PdfArray pdfOptionNames = pdfNames.ToPdfArray();
+        PdfArray<PdfName> pdfOptionNames = pdfNames.ToPdfArray();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.FileDecodeParameters = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "FDecodeParms";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -200,7 +200,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfArray actualPdfArray = Assert.IsType<PdfArray>(optionValue);
+        PdfArray<PdfName> actualPdfArray = Assert.IsType<PdfArray<PdfName>>(optionValue);
         Assert.Equal(decodeParameters.Length, actualPdfArray.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfArray.Value);
     }
@@ -209,15 +209,15 @@ public class PdfStreamTests
     public void PdfStream_ConstructorWithDecodeParametersDictionary_ShouldReturnValidStreamExtend()
     {
         // Arrange
-        IDictionary<PdfName, IPdfObject> decodeParameters = new Dictionary<PdfName, IPdfObject> { { "Colors", new PdfName("None") } };
-        PdfDictionary pdfOptionNames = decodeParameters.ToPdfDictionary();
+        IDictionary<PdfName, PdfName> decodeParameters = new Dictionary<PdfName, PdfName> { { "Colors", new PdfName("None") } };
+        PdfDictionary<PdfName> pdfOptionNames = decodeParameters.ToPdfDictionary();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.DecodeParameters = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "DecodeParms";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -225,7 +225,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfDictionary actualPdfDictionary = Assert.IsType<PdfDictionary>(optionValue);
+        PdfDictionary<PdfName> actualPdfDictionary = Assert.IsType<PdfDictionary<PdfName>>(optionValue);
         Assert.Equal(decodeParameters.Count, actualPdfDictionary.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfDictionary.Value);
     }
@@ -234,15 +234,15 @@ public class PdfStreamTests
     public void PdfStream_ConstructorWithFileDecodeParametersDictionary_ShouldReturnValidStreamExtend()
     {
         // Arrange
-        IDictionary<PdfName, IPdfObject> decodeParameters = new Dictionary<PdfName, IPdfObject> { { "Colors", new PdfName("None") } };
-        PdfDictionary pdfOptionNames = decodeParameters.ToPdfDictionary();
+        IDictionary<PdfName, PdfName> decodeParameters = new Dictionary<PdfName, PdfName> { { "Colors", new PdfName("None") } };
+        PdfDictionary<PdfName> pdfOptionNames = decodeParameters.ToPdfDictionary();
         PdfStream pdfStream = new PdfString("Test").ToPdfStream(options => options.FileDecodeParameters = pdfOptionNames);
         const int expectedDictionaryCount = 2; // Count + Current extent option
         const string expectedLengthKeyName = "Length";
         const string expectedOptionKeyName = "FDecodeParms";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -250,7 +250,7 @@ public class PdfStreamTests
         Assert.Equal(expectedDictionaryCount, actualStreamExtent.Value.Count);
         Assert.True(isLengthInDictionary);
         Assert.True(isOptionInDictionary);
-        PdfDictionary actualPdfDictionary = Assert.IsType<PdfDictionary>(optionValue);
+        PdfDictionary<PdfName> actualPdfDictionary = Assert.IsType<PdfDictionary<PdfName>>(optionValue);
         Assert.Equal(decodeParameters.Count, actualPdfDictionary.Value.Count);
         Assert.Equal(pdfOptionNames.Value, actualPdfDictionary.Value);
     }
@@ -268,7 +268,7 @@ public class PdfStreamTests
         const string expectedOptionKeyName = "F";
 
         // Act
-        PdfDictionary actualStreamExtent = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent = pdfStream.StreamExtent;
         bool isLengthInDictionary = actualStreamExtent.Value.TryGetValue(expectedLengthKeyName, out IPdfObject _);
         bool isOptionInDictionary = actualStreamExtent.Value.TryGetValue(expectedOptionKeyName, out IPdfObject? optionValue);
 
@@ -287,8 +287,8 @@ public class PdfStreamTests
         PdfStream pdfStream = new PdfString("Test").ToPdfStream();
 
         // Act
-        PdfDictionary actualStreamExtent1 = pdfStream.StreamExtent;
-        PdfDictionary actualStreamExtent2 = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent1 = pdfStream.StreamExtent;
+        PdfDictionary<IPdfObject> actualStreamExtent2 = pdfStream.StreamExtent;
 
         // Assert
         Assert.True(ReferenceEquals(actualStreamExtent1, actualStreamExtent2));


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.5.4`, the trailer enables a conforming reader to quickly find the cross-reference table and certain special objects. The PDF readers start to read the file from the end.

The trailer is consisted of the following parts:
- trailer dictionary
- startxref keyword
- byte offset of the last cross-reference section
- end-of-file marker  `%%EOF`.


File Trailed example:

```
trailer
  <<
    key_1 value_1
    key_2 value_2
    …
    key_n value_n
  >>
startxref
  Byte_offset_of_last_cross-reference_section
%%EOF
```

### Acceptance criteria

1. File trailed dictionary should support the following entries:
   | Key | Type | Description | Required | Other constraints |
   | --- | --- | --- | --- | --- |
   | Size | integer | Number of entries in the XRef table | ✅ |  |
   | Prev | integer | Byte offset of the previous XRef section | ❓ | Indirect reference<br>Required if the file has more than one XRef section |
   | Root | dictionary | Document catalog dictionary | ✅ | Indirect reference<br>#24 |
   | Encrypt | dictionary | Document encryption dictionary |❓| Required if document is encrypted<br>#34 |
   | Info | dictionary | Document information dictionary | | Indirect reference<br>#35 |
   | ID | array | Array of two byte-strings constituting a file identifier |❓| Required if an `Encrypt` entry is present |
1. The trailed dictionary should be followed by the `startxref` keyword, then by the `byte offset` of the `last cross-reference section`, and ending with the end-of-file marker  `%%EOF`.
1. The code should be covered with the unit, and mutation tests.
