### PR TITLE
feat(common-data-structures): added rectangle object

### DIFF
--- a/src/Off.Net.Pdf.Core/CommonDataStructures/Rectangle.cs
+++ b/src/Off.Net.Pdf.Core/CommonDataStructures/Rectangle.cs
@@ -1,0 +1,31 @@
+﻿using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.CommonDataStructures;
+
+public class Rectangle : PdfArray<PdfInteger>
+{
+    #region Constructors
+
+    public Rectangle(int lowerLeftX, int lowerLeftY, int upperRightX, int upperRightY) : base(new List<PdfInteger> { lowerLeftX, lowerLeftY, upperRightX, upperRightY })
+    {
+        LowerLeftX = lowerLeftX.CheckConstraints(x => x >= 0, Resource.Rectangle_PointMustBePositive);
+        LowerLeftY = lowerLeftY.CheckConstraints(x => x >= 0, Resource.Rectangle_PointMustBePositive);
+        UpperRightX = upperRightX.CheckConstraints(x => x >= 0, Resource.Rectangle_PointMustBePositive);
+        UpperRightY = upperRightY.CheckConstraints(x => x >= 0, Resource.Rectangle_PointMustBePositive);
+    }
+
+    #endregion
+
+    #region Properties
+
+    public int LowerLeftX { get; }
+
+    public int LowerLeftY { get; }
+
+    public int UpperRightX { get; }
+
+    public int UpperRightY { get; }
+
+    #endregion
+}

--- a/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
+++ b/src/Off.Net.Pdf.Core/Primitives/PdfArray.cs
@@ -3,7 +3,7 @@ using Off.Net.Pdf.Core.Interfaces;
 
 namespace Off.Net.Pdf.Core.Primitives;
 
-public sealed class PdfArray<TValue> : IPdfObject<IReadOnlyCollection<TValue>>, IEquatable<PdfArray<TValue>?> where TValue: IPdfObject
+public class PdfArray<TValue> : IPdfObject<IReadOnlyCollection<TValue>> where TValue: IPdfObject
 {
     #region Fields
     private readonly int _hashCode;
@@ -38,13 +38,7 @@ public sealed class PdfArray<TValue> : IPdfObject<IReadOnlyCollection<TValue>>, 
 
     public override bool Equals(object? obj)
     {
-        return Equals(obj as PdfArray<TValue>);
-    }
-
-    public bool Equals(PdfArray<TValue>? other)
-    {
-        return other is not null &&
-               EqualityComparer<IReadOnlyCollection<TValue>>.Default.Equals(Value, other.Value);
+        return obj is PdfArray<TValue> other && EqualityComparer<IReadOnlyCollection<TValue>>.Default.Equals(Value, other.Value);
     }
 
     public static PdfArray<TValue> CreateRange(IEnumerable<TValue> items)

--- a/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.Designer.cs
@@ -222,6 +222,15 @@ namespace Off.Net.Pdf.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The point provided must be a positive number.
+        /// </summary>
+        internal static string Rectangle_PointMustBePositive {
+            get {
+                return ResourceManager.GetString("Rectangle_PointMustBePositive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The byte offset of the XRef entry must be positive.
         /// </summary>
         internal static string XRefEntry_ByteOffsetMustBePositive {

--- a/src/Off.Net.Pdf.Core/Properties/Resource.resx
+++ b/src/Off.Net.Pdf.Core/Properties/Resource.resx
@@ -191,4 +191,7 @@
   <data name="DocumentCatalog_Pages_MustNotBeEmpty" xml:space="preserve">
     <value>The document catalog dictionary must contain a non-empty Pages dictionary</value>
   </data>
+  <data name="Rectangle_PointMustBePositive" xml:space="preserve">
+    <value>The point provided must be a positive number</value>
+  </data>
 </root>

--- a/tests/Off.Net.Pdf.Core.Tests/CommonDataStructures/RectangleTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/CommonDataStructures/RectangleTests.cs
@@ -1,0 +1,60 @@
+﻿using Off.Net.Pdf.Core.CommonDataStructures;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.CommonDataStructures;
+
+public sealed class RectangleTests
+{
+    [Theory(DisplayName = $"Constructor with a negative points should throw an {nameof(ArgumentOutOfRangeException)}")]
+    [InlineData(-1, 0, 1, 2)]
+    [InlineData(0, -1, 1, 2)]
+    [InlineData(0, 1, -1, 2)]
+    [InlineData(0, 1, 2, -1)]
+    public void Rectangle_ConstructorWithNegativePoints_ShouldThrowException(int lowerLeftX, int lowerLeftY, int upperRightX, int upperRightY)
+    {
+        // Arrange
+
+        // Act
+        Rectangle RectangleFunction() => new(lowerLeftX, lowerLeftY, upperRightX, upperRightY);
+
+        // Assert
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(RectangleFunction);
+        Assert.StartsWith(Resource.Rectangle_PointMustBePositive, exception.Message);
+    }
+
+    [Theory(DisplayName = $"The properties of a ${nameof(Rectangle)} should match the values provided in the constructor")]
+    [InlineData(0, 1, 2, 3)]
+    [InlineData(123, 46, 456, 72)]
+    public void Rectangle_PointsProperties_ShouldReturnValidValues(int lowerLeftX, int lowerLeftY, int upperRightX, int upperRightY)
+    {
+        // Arrange
+        Rectangle rectangle = new(lowerLeftX, lowerLeftY, upperRightX, upperRightY);
+
+        // Act
+        int actualLowerLeftX = rectangle.LowerLeftX;
+        int actualLowerLeftY = rectangle.LowerLeftY;
+        int actualUpperRightX = rectangle.UpperRightX;
+        int actualUpperRightY = rectangle.UpperRightY;
+
+        // Assert
+        Assert.Equal(actualLowerLeftX, lowerLeftX);
+        Assert.Equal(actualLowerLeftY, lowerLeftY);
+        Assert.Equal(actualUpperRightX, upperRightX);
+        Assert.Equal(actualUpperRightY, upperRightY);
+    }
+
+    [Theory(DisplayName = $"The {nameof(Rectangle.Content)} property should return a valid value")]
+    [InlineData(0, 1, 2, 3, "[0 1 2 3]")]
+    [InlineData(123, 46, 456, 72, "[123 46 456 72]")]
+    public void Rectangle_Content_ShouldReturnValidValue(int lowerLeftX, int lowerLeftY, int upperRightX, int upperRightY, string expectedContent)
+    {
+        // Arrange
+        Rectangle rectangle = new(lowerLeftX, lowerLeftY, upperRightX, upperRightY);
+
+        // Act
+        string actualContent = rectangle.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.9.5`, Rectangles are used to describe locations on a page and bounding boxes for a variety of objects. A rectangle shall be written as an array of four numbers giving the coordinates of a pair of diagonally opposite corners. 

Default form: $[ll_x\space ll_y\space ur_x\space ur_y]$, where the values correspond to:
1. lower-left x
2. lower-left y
3. upper-right x
4. upper-right y

![Rectangle form](https://user-images.githubusercontent.com/24962085/223048679-bda235d3-605a-4916-b4c8-e78a487c195b.png)

Even though the specification allows using any two diagonally opposite corners, this story will be focusing on supporting the above-described rectangle form.

### Acceptance criteria

1. This object must extend the #8 
2. The code must be covered with the unit tests