### PR TITLE
feat(font): added basic Type1 font and the standard 14 fonts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.53.0.62665">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.54.0.64047">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Off.Net.sln
+++ b/Off.Net.sln
@@ -45,7 +45,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{293A6DEE
 		tools\code-coverage.ps1 = tools\code-coverage.ps1
 		tools\mutation-testing.bat = tools\mutation-testing.bat
 		tools\mutation-testing.ps1 = tools\mutation-testing.ps1
+		tools\benchmarks.bat = tools\benchmarks.bat
+		tools\benchmarks.ps1 = tools\benchmarks.ps1
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{F1BF62EB-6D20-45E2-8546-1BEDD3408AF2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Off.Net.Pdf.Core.Benchmarks", "benchmarks\Off.Net.Pdf.Core.Benchmarks\Off.Net.Pdf.Core.Benchmarks.csproj", "{0D089F68-B320-4C77-B0EC-83515B4E2E22}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,6 +67,10 @@ Global
 		{C09DDCF0-700D-46DA-BD9A-B3340E2E76B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C09DDCF0-700D-46DA-BD9A-B3340E2E76B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C09DDCF0-700D-46DA-BD9A-B3340E2E76B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,6 +81,7 @@ Global
 		{E5BBC6F7-E046-48B6-A870-D115644713DD} = {D587B5E1-06B4-4CA7-8FE4-62B0DF71BAD6}
 		{9BFC64AB-0E3C-4EE2-959E-7D5F0455ADC4} = {E5BBC6F7-E046-48B6-A870-D115644713DD}
 		{293A6DEE-237E-45F8-B770-717F6846A913} = {D587B5E1-06B4-4CA7-8FE4-62B0DF71BAD6}
+		{0D089F68-B320-4C77-B0EC-83515B4E2E22} = {F1BF62EB-6D20-45E2-8546-1BEDD3408AF2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1C5CCEAE-E0B4-4074-9291-2AAD38F9117F}

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/CommonDataStructures/RectangleBenchmarks.cs
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/CommonDataStructures/RectangleBenchmarks.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using Off.Net.Pdf.Core.CommonDataStructures;
+
+namespace Off.Net.Pdf.Core.Benchmarks.CommonDataStructures;
+
+public class RectangleBenchmarks
+{
+    [Benchmark]
+    public Rectangle BasicRectangle()
+    {
+        return new Rectangle(123, 46, 456, 72);
+    }
+
+    [Benchmark]
+    public ReadOnlyMemory<byte> BasicRectangle_Bytes()
+    {
+        return new Rectangle(123, 46, 456, 72).Bytes;
+    }
+
+    [Benchmark]
+    public int BasicRectangle_Length()
+    {
+        return new Rectangle(123, 46, 456, 72).Length;
+    }
+
+    [Benchmark]
+    public string BasicRectangle_Content()
+    {
+        return new Rectangle(123, 46, 456, 72).Content;
+    }
+}

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/Off.Net.Pdf.Core.Benchmarks.csproj
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/Off.Net.Pdf.Core.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Off.Net.Pdf.Core.Benchmarks</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/Program.cs
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/Program.cs
@@ -1,0 +1,10 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Running;
+
+var config = DefaultConfig.Instance
+    .AddDiagnoser(MemoryDiagnoser.Default)
+    .AddExporter(JsonExporter.Default);
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/packages.lock.json
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/packages.lock.json
@@ -1,0 +1,257 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "BenchmarkDotNet": {
+        "type": "Direct",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "PiwINqvreKV7L+BQlaZ2qcJ90s88LbLqZoUWbKnEPzvmsWd4pUH58Yjp+mFn311n8Jz0Y0JsD+jWa+Kh67IG3A==",
+        "dependencies": {
+          "BenchmarkDotNet.Annotations": "0.13.5",
+          "CommandLineParser": "2.4.3",
+          "Gee.External.Capstone": "2.3.0",
+          "Iced": "1.17.0",
+          "Microsoft.CodeAnalysis.CSharp": "3.0.0",
+          "Microsoft.Diagnostics.Runtime": "2.2.332302",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2",
+          "Microsoft.DotNet.PlatformAbstractions": "3.1.6",
+          "Perfolizer": "0.2.1",
+          "System.Management": "6.0.0"
+        }
+      },
+      "BenchmarkDotNet.Diagnostics.Windows": {
+        "type": "Direct",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "bNKJlIgUvEMBotiiHrEzw2xyCFlNiEfE14/EcBOEDSgYg+spzByVVv+totq9baxKUk5MhfAFhyzguBMiuoho3Q==",
+        "dependencies": {
+          "BenchmarkDotNet": "0.13.5",
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2"
+        }
+      },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
+      },
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[8.54.0.64047, )",
+        "resolved": "8.54.0.64047",
+        "contentHash": "wqDNtVY4UDRximKGZ+XmDL19F2zjaCgn4r+j4VmyVL1iBYtbkQmYOiijrkHjzVS2QgTkdDhalsJ+6DUqjBfVhw=="
+      },
+      "BenchmarkDotNet.Annotations": {
+        "type": "Transitive",
+        "resolved": "0.13.5",
+        "contentHash": "ORcRi9/fnjRfINKiAnAgIsRlQ15Gj2Lki7AluHnAVMk/lTyQ2nwaa+F+ezW8f3tElBDoZql02+J2lIwHbu1eoA=="
+      },
+      "CommandLineParser": {
+        "type": "Transitive",
+        "resolved": "2.4.3",
+        "contentHash": "U2FC9Y8NyIxxU6MpFFdWWu1xwiqz/61v/Doou7kmVjpeIEMLWyiNNkzNlSE84kyJ0O1LKApuEj5z48Ow0Hi4OQ=="
+      },
+      "Gee.External.Capstone": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2ap/rYmjtzCOT8hxrnEW/QeiOt+paD8iRrIcdKX0cxVwWLFa1e+JDBNeECakmccXrSFeBQuu5AV8SNkipFMMMw=="
+      },
+      "Iced": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "8x+HCVTl/HHTGpscH3vMBhV8sknN/muZFw9s3TsI8SA6+c43cOTCi2+jE4KsU8pNLbJ++iF2ZFcpcXHXtDglnw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "1Am6l4Vpn3/K32daEqZI+FFr96OlZkgwK2LcT3pZ2zWubR5zTPW3/FkO1Rat9kb7oQOa4rxgl9LJHc5tspCWfg=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "2.6.2-beta2",
+        "contentHash": "rg5Ql73AmGCMG5Q40Kzbndq7C7S4XvsJA+2QXfZBCy2dRqD+a7BSbx/3942EoRUJ/8Wh9+kLg2G2qC46o3f1Aw=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "HEnLZ9Op5IoXeuokhfSLIXstXfEyPzXhQ/xsnvUmxzb+7YpwuLk57txArzGs/Wne5bWmU7Uey4Q1jUZ3++heqg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "2.6.2-beta2",
+          "System.Collections.Immutable": "1.5.0",
+          "System.Memory": "4.5.1",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.0",
+          "System.Text.Encoding.CodePages": "4.5.0",
+          "System.Threading.Tasks.Extensions": "4.5.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "hWFUxc0iUbVvIKWJODErOeOa5GiqZuEcetxaCfHqZ04zHy0ZCLx3v4/TdF/6Erx1mXPHfoT2Tiz5rZCQZ6OyxQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[3.0.0]"
+        }
+      },
+      "Microsoft.Diagnostics.NETCore.Client": {
+        "type": "Transitive",
+        "resolved": "0.2.251802",
+        "contentHash": "bqnYl6AdSeboeN4v25hSukK6Odm6/54E3Y2B8rBvgqvAW0mF8fo7XNRVE2DMOG7Rk0fiuA079QIH28+V+W1Zdg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.0",
+          "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
+      "Microsoft.Diagnostics.Runtime": {
+        "type": "Transitive",
+        "resolved": "2.2.332302",
+        "contentHash": "Hp84ivxSKIMTBzYSATxmUsm3YSXHWivcwiRRbsydGmqujMUK8BAueLN0ssAVEOkOBmh0vjUBhrq7YcroT7VCug==",
+        "dependencies": {
+          "Microsoft.Diagnostics.NETCore.Client": "0.2.251802",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
+      "Microsoft.Diagnostics.Tracing.TraceEvent": {
+        "type": "Transitive",
+        "resolved": "3.0.2",
+        "contentHash": "Pr7t+Z/qBe6DxCow4BmYmDycHe2MrGESaflWXRcSUI4XNGyznx1ttS+9JNOxLuBZSoBSPTKw9Dyheo01Yi6anQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions": {
+        "type": "Transitive",
+        "resolved": "3.1.6",
+        "contentHash": "jek4XYaQ/PGUwDKKhwR8K47Uh1189PFzMeLqO83mXrXQVIpARZCcfuDedH50YDTepBkfijCZN5U/vZi++erxtg=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "LjVKO6P2y52c5ZhTLX/w8zc5H4Y3J/LJsgqTBj49TtFq/hAtVNue/WA0F6/7GMY90xhD7K0MDZ4qpOeWXbLvzg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "VfuZJNa0WUshZ/+8BFZAhwFKiKuu/qOUCFntfdLpHj7vcRnsGHqd3G2Hse78DM+pgozczGM63lGPRLmy+uhUOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "fcLCTS03poWE4v9tSNBr3pWn0QwGgAn1vzqHXlXgvqZeOc7LvQNzaWcKRQZTdEc3+YhQKwMsOtm3VKSA2aWQ8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "MgYpU5cwZohUMKKg3sbPhvGG+eAZ/59E9UwPwlrUkyXU+PGzqwZg9yyQNjhxuAWmoNoFReoemeCku50prYSGzA=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "hh+mkOAQDTp6XH80xJt3+wwYVzkbwYQl9XZRCz4Um0JjP/o7N9vHM3rZ6wwwtr+BBe/L6iBO2sz0px6OWBzqZQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "2.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Options": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "XRzK7ZF+O6FzdfWrlFTi1Rgj2080ZDsd46vzOjadHUB0Cz5kOvDG8vI7caa5YFrsHQpcfn0DxtjS4E46N4FZsA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "V7lXCU78lAbzaulCGFKojcCyG8RTJicEbiBkPJjFqiqXwndEBBIehdXRMWEVU3UtzQ1yDvphiWUL9th6/4gJ7w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Primitives": "2.1.1"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "scJ1GZNIxMmjpENh0UZ8XCQ6vzr/LzeF9WvEA51Ix2OQGAs9WPgPu8ABVUdvpKPLuor/t05gm6menJK3PwqOXg==",
+        "dependencies": {
+          "System.Memory": "4.5.1",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.1"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "VdLJOCXhZaEMY7Hm2GKiULmn7IEPFE4XC5LPSfBVCUIA8YLZVh846gtfBJalsPQF2PlzdD7ecX7DZEulJ402ZQ=="
+      },
+      "Perfolizer": {
+        "type": "Transitive",
+        "resolved": "0.2.1",
+        "contentHash": "Dt4aCxCT8NPtWBKA8k+FsN/RezOQ2C6omNGm5o/qmYRiIwlQYF93UgFmeF1ezVNsztTnkg7P5P63AE+uNkLfrw==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "sHsESYMmPDhQuOC66h6AEOs/XowzKsbT9srMbX71TCXP58hkpn1BqBjdmKj1+DCA/WlBETX1K5WjQHwmV0Txrg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "S0wEUiKcLvRlkFUXca8uio1UQ5bYQzYgOmOKtCqaBQC3GR9AJjh43otcM32IGsAyvadFTaAMw9Irm6dS4Evfng==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "2.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "csAJe24tWCOTO/rXoJAuBGuOq7ZdHY60XtC6b/hNMHT9tuX+2J9HK7nciLEtNvnrRLMxBACLXO3R4y5+kCduMA=="
+      },
+      "off.net.pdf.core": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Off.Net.Pdf.Core/Text/Fonts/StandardFonts.cs
+++ b/src/Off.Net.Pdf.Core/Text/Fonts/StandardFonts.cs
@@ -1,0 +1,88 @@
+﻿namespace Off.Net.Pdf.Core.Text.Fonts;
+
+public static class StandardFonts
+{
+    public static readonly Type1Font TimesRoman = new(options =>
+    {
+        options.FontName = "Times-Roman";
+        options.BaseFont = "Times-Roman";
+    });
+
+    public static readonly Type1Font TimesBold = new(options =>
+    {
+        options.FontName = "Times-Bold";
+        options.BaseFont = "Times-Bold";
+    });
+
+    public static readonly Type1Font TimesItalic = new(options =>
+    {
+        options.FontName = "Times-Italic";
+        options.BaseFont = "Times-Italic";
+    });
+
+    public static readonly Type1Font TimesBoldItalic = new(options =>
+    {
+        options.FontName = "Times-BoldItalic";
+        options.BaseFont = "Times-BoldItalic";
+    });
+
+    public static readonly Type1Font Helvetica = new(options =>
+    {
+        options.FontName = "Helvetica";
+        options.BaseFont = "Helvetica";
+    });
+
+    public static readonly Type1Font HelveticaBold = new(options =>
+    {
+        options.FontName = "Helvetica-Bold";
+        options.BaseFont = "Helvetica-Bold";
+    });
+
+    public static readonly Type1Font HelveticaOblique = new(options =>
+    {
+        options.FontName = "Helvetica-Oblique";
+        options.BaseFont = "Helvetica-Oblique";
+    });
+
+    public static readonly Type1Font HelveticaBoldOblique = new(options =>
+    {
+        options.FontName = "Helvetica-BoldOblique";
+        options.BaseFont = "Helvetica-BoldOblique";
+    });
+
+    public static readonly Type1Font Courier = new(options =>
+    {
+        options.FontName = "Courier";
+        options.BaseFont = "Courier";
+    });
+
+    public static readonly Type1Font CourierBold = new(options =>
+    {
+        options.FontName = "Courier-Bold";
+        options.BaseFont = "Courier-Bold";
+    });
+
+    public static readonly Type1Font CourierOblique = new(options =>
+    {
+        options.FontName = "Courier-Oblique";
+        options.BaseFont = "Courier-Oblique";
+    });
+
+    public static readonly Type1Font CourierBoldOblique = new(options =>
+    {
+        options.FontName = "Courier-BoldOblique";
+        options.BaseFont = "Courier-BoldOblique";
+    });
+
+    public static readonly Type1Font Symbol = new(options =>
+    {
+        options.FontName = "Symbol";
+        options.BaseFont = "Symbol";
+    });
+
+    public static readonly Type1Font ZapfDingbats = new(options =>
+    {
+        options.FontName = "ZapfDingbats";
+        options.BaseFont = "ZapfDingbats";
+    });
+}

--- a/src/Off.Net.Pdf.Core/Text/Fonts/Type1Font.cs
+++ b/src/Off.Net.Pdf.Core/Text/Fonts/Type1Font.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.ObjectModel;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.Text.Fonts;
+
+public sealed class Type1Font : PdfDictionary<IPdfObject>
+{
+    #region Fields
+
+    private static readonly PdfName Type = new("Type");
+    private static readonly PdfName TypeValue = new("Font");
+    private static readonly PdfName Subtype = new("Subtype");
+    private static readonly PdfName SubtypeValue = new("Type1");
+    private static readonly PdfName FontName = new("Name");
+    private static readonly PdfName BaseFont = new("BaseFont");
+
+    #endregion
+
+    #region Constructors
+
+    public Type1Font(Action<Type1FontOptions> optionsFunc) : this(GetType1FontOptions(optionsFunc))
+    {
+    }
+
+    public Type1Font(Type1FontOptions options) : base(GenerateDictionary(options))
+    {
+        options.NotNull(x => x.BaseFont);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private static Type1FontOptions GetType1FontOptions(Action<Type1FontOptions> optionsFunc)
+    {
+        Type1FontOptions fileTrailerOptions = new();
+        optionsFunc.Invoke(fileTrailerOptions);
+        return fileTrailerOptions;
+    }
+
+    private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(Type1FontOptions options)
+    {
+        IDictionary<PdfName, IPdfObject> documentCatalogDictionary = new Dictionary<PdfName, IPdfObject>(4)
+            .WithKeyValue(Type, TypeValue)
+            .WithKeyValue(Subtype, SubtypeValue)
+            .WithKeyValue(FontName, options.FontName)
+            .WithKeyValue(BaseFont, options.BaseFont);
+
+        return new ReadOnlyDictionary<PdfName, IPdfObject>(documentCatalogDictionary);
+    }
+
+    #endregion
+}
+
+public sealed class Type1FontOptions
+{
+    public PdfName? FontName { get; set; }
+    public PdfName BaseFont { get; set; } = default!;
+}

--- a/src/Off.Net.Pdf.Core/packages.lock.json
+++ b/src/Off.Net.Pdf.Core/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.53.0.62665, )",
-        "resolved": "8.53.0.62665",
-        "contentHash": "95zMbdyOocAs7TCvfw+sRMSWMOCYDV6kKkoBW7vO1yY0RZOb3gg6k7ql9EzgWY6tZknBqYg7qWUa2CPoiQkt5w=="
+        "requested": "[8.54.0.64047, )",
+        "resolved": "8.54.0.64047",
+        "contentHash": "wqDNtVY4UDRximKGZ+XmDL19F2zjaCgn4r+j4VmyVL1iBYtbkQmYOiijrkHjzVS2QgTkdDhalsJ+6DUqjBfVhw=="
       }
     }
   }

--- a/tests/Off.Net.Pdf.Core.Tests/Text/Fonts/Type1FontTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Text/Fonts/Type1FontTests.cs
@@ -1,0 +1,62 @@
+﻿using Off.Net.Pdf.Core.Text.Fonts;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.Text.Fonts;
+
+public class Type1FontTests
+{
+    [Fact(DisplayName = $"Constructor with a null {nameof(Type1FontOptions.BaseFont)} value should throw an {nameof(ArgumentNullException)}")]
+    public void Type1Font_ConstructorWithNullBaseFont_ShouldThrowException()
+    {
+        // Arrange
+        Type1FontOptions documentCatalogOptions = new() { BaseFont = null! };
+
+        // Act
+        Type1Font Type1FontFunction() => new(documentCatalogOptions);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(Type1FontFunction);
+    }
+
+    [Theory(DisplayName = $"The {nameof(Type1Font.Content)} should return a valid value")]
+    [MemberData(nameof(Type1FontTestsDataGenerator.Type1Font_Content_TestCases), MemberType = typeof(Type1FontTestsDataGenerator))]
+    public void Type1Font_Content_ShouldReturnValidValue(Type1Font type1Font, string expectedContent)
+    {
+        // Arrange
+
+        // Act
+        string actualContent = type1Font.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent);
+    }
+}
+
+internal static class Type1FontTestsDataGenerator
+{
+    private static readonly Type1FontOptions Options = new() { BaseFont = "Helvetica", FontName = "Custom-Font" };
+    private static readonly Type1Font CustomType1Font = new(Options);
+
+    private static readonly Type1FontOptions OptionsWithoutName = new() { BaseFont = "Helvetica" };
+    private static readonly Type1Font CustomType1FontWithoutName = new(OptionsWithoutName);
+
+    public static IEnumerable<object[]> Type1Font_Content_TestCases()
+    {
+        yield return new object[] { StandardFonts.TimesRoman, "<</Type /Font /Subtype /Type1 /Name /Times-Roman /BaseFont /Times-Roman>>" };
+        yield return new object[] { StandardFonts.TimesBold, "<</Type /Font /Subtype /Type1 /Name /Times-Bold /BaseFont /Times-Bold>>" };
+        yield return new object[] { StandardFonts.TimesItalic, "<</Type /Font /Subtype /Type1 /Name /Times-Italic /BaseFont /Times-Italic>>" };
+        yield return new object[] { StandardFonts.TimesBoldItalic, "<</Type /Font /Subtype /Type1 /Name /Times-BoldItalic /BaseFont /Times-BoldItalic>>" };
+        yield return new object[] { StandardFonts.Helvetica, "<</Type /Font /Subtype /Type1 /Name /Helvetica /BaseFont /Helvetica>>" };
+        yield return new object[] { StandardFonts.HelveticaBold, "<</Type /Font /Subtype /Type1 /Name /Helvetica-Bold /BaseFont /Helvetica-Bold>>" };
+        yield return new object[] { StandardFonts.HelveticaOblique, "<</Type /Font /Subtype /Type1 /Name /Helvetica-Oblique /BaseFont /Helvetica-Oblique>>" };
+        yield return new object[] { StandardFonts.HelveticaBoldOblique, "<</Type /Font /Subtype /Type1 /Name /Helvetica-BoldOblique /BaseFont /Helvetica-BoldOblique>>" };
+        yield return new object[] { StandardFonts.Courier, "<</Type /Font /Subtype /Type1 /Name /Courier /BaseFont /Courier>>" };
+        yield return new object[] { StandardFonts.CourierBold, "<</Type /Font /Subtype /Type1 /Name /Courier-Bold /BaseFont /Courier-Bold>>" };
+        yield return new object[] { StandardFonts.CourierOblique, "<</Type /Font /Subtype /Type1 /Name /Courier-Oblique /BaseFont /Courier-Oblique>>" };
+        yield return new object[] { StandardFonts.CourierBoldOblique, "<</Type /Font /Subtype /Type1 /Name /Courier-BoldOblique /BaseFont /Courier-BoldOblique>>" };
+        yield return new object[] { StandardFonts.Symbol, "<</Type /Font /Subtype /Type1 /Name /Symbol /BaseFont /Symbol>>" };
+        yield return new object[] { StandardFonts.ZapfDingbats, "<</Type /Font /Subtype /Type1 /Name /ZapfDingbats /BaseFont /ZapfDingbats>>" };
+        yield return new object[] { CustomType1Font, "<</Type /Font /Subtype /Type1 /Name /Custom-Font /BaseFont /Helvetica>>" };
+        yield return new object[] { CustomType1FontWithoutName, "<</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>" };
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/packages.lock.json
+++ b/tests/Off.Net.Pdf.Core.Tests/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.53.0.62665, )",
-        "resolved": "8.53.0.62665",
-        "contentHash": "95zMbdyOocAs7TCvfw+sRMSWMOCYDV6kKkoBW7vO1yY0RZOb3gg6k7ql9EzgWY6tZknBqYg7qWUa2CPoiQkt5w=="
+        "requested": "[8.54.0.64047, )",
+        "resolved": "8.54.0.64047",
+        "contentHash": "wqDNtVY4UDRximKGZ+XmDL19F2zjaCgn4r+j4VmyVL1iBYtbkQmYOiijrkHjzVS2QgTkdDhalsJ+6DUqjBfVhw=="
       },
       "xunit": {
         "type": "Direct",

--- a/tools/benchmarks.bat
+++ b/tools/benchmarks.bat
@@ -1,0 +1,1 @@
+Powershell.exe -executionpolicy unrestricted -File %~dp0\benchmarks.ps1

--- a/tools/benchmarks.ps1
+++ b/tools/benchmarks.ps1
@@ -1,0 +1,15 @@
+Set-StrictMode -Version Latest
+
+try {
+    Set-Location $PSScriptRoot\..\benchmarks\Off.Net.Pdf.Core.Benchmarks
+
+    dotnet run -c Release2 -- --job short --runtimes net6.0 --filter *
+}
+catch {
+    Write-Error "An error occurred: $_. Press any key to continue or Ctrl+C to exit."
+    $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown") | Out-Null
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `9.6.2`, a `Type 1` font program is a stylized PostScript program that describes glyph shapes. This object is represented as a PDF dictionary.

This dictionary has an entire list of entries but this user story will be focused on supporting only the essential ones for the standard 14 fonts.

### Required entries

| Key | Type | Constraints |
| --- | --- | --- |
| Type | name | Required, must be `Font` |
| Subtype | name | Required, must be `Type1` |
| Name | name | Required in PDF1.0 but the validation will be skipped in this story |
| BaseFont | name | Required, in the context of this story the name must match one of 14 standard fonts |

### Standard 14 fonts

The PostScript names of 14 Type 1 fonts, known as the standard 14 fonts, are as follows:

- Times-Roman
- Helvetica
- Courier
- Symbol
- Times-Bold
- Helvetica-Bold
- Courier-Bold
- ZapfDingbats
- Times-Italic
- Helvetica-Oblique
- Courier-Oblique
- Times-BoldItalic
- Helvetica-BoldOblique
- Courier-BoldOblique

### Acceptance criteria

1. This object must extend the #9
2. Add the static standard 14 fonts, ~~probably using a Lazy initialization pattern~~
3. The code must be covered with the unit tests