### PR TITLE
feat(content-stream-and-resources): added basic resource dictionary

### DIFF
--- a/src/Off.Net.Pdf.Core/ContentStreamAndResources/ResourceDictionary.cs
+++ b/src/Off.Net.Pdf.Core/ContentStreamAndResources/ResourceDictionary.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.ObjectModel;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text.Fonts;
+
+namespace Off.Net.Pdf.Core.ContentStreamAndResources;
+
+public sealed class ResourceDictionary : PdfDictionary<IPdfObject>
+{
+    #region Fields
+
+    private static readonly PdfName Font = new("Font");
+
+    #endregion
+
+    #region Constructors
+
+    public ResourceDictionary(Action<ResourceDictionaryOptions> optionsFunc) : this(GetResourceDictionaryOptions(optionsFunc))
+    {
+    }
+
+    public ResourceDictionary(ResourceDictionaryOptions options) : base(GenerateDictionary(options))
+    {
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private static ResourceDictionaryOptions GetResourceDictionaryOptions(Action<ResourceDictionaryOptions> optionsFunc)
+    {
+        ResourceDictionaryOptions fileTrailerOptions = new();
+        optionsFunc.Invoke(fileTrailerOptions);
+        return fileTrailerOptions;
+    }
+
+    private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(ResourceDictionaryOptions options)
+    {
+        IDictionary<PdfName, IPdfObject> documentCatalogDictionary = new Dictionary<PdfName, IPdfObject>(1)
+            .WithKeyValue(Font, options.Font);
+
+        return new ReadOnlyDictionary<PdfName, IPdfObject>(documentCatalogDictionary);
+    }
+
+    #endregion
+}
+
+public sealed class ResourceDictionaryOptions
+{
+    public PdfDictionary<PdfIndirectIdentifier<Type1Font>>? Font { get; set; }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/ContentStreamAndResources/ResourceDictionaryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/ContentStreamAndResources/ResourceDictionaryTests.cs
@@ -1,0 +1,47 @@
+﻿using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text.Fonts;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.ContentStreamAndResources;
+
+public class ResourceDictionaryTests
+{
+    [Theory(DisplayName = $"The {nameof(ResourceDictionary)} with provided {nameof(ResourceDictionaryOptions.Font)} sub-dictionary should return a valid value")]
+    [MemberData(nameof(ResourceDictionaryTestsDataGenerator.ResourceDictionary_Content_TestCases), MemberType = typeof(ResourceDictionaryTestsDataGenerator))]
+    public void ResourceDictionary_Content_ShouldReturnValidValue(ResourceDictionaryOptions resourceDictionaryOptions, string expectedContent)
+    {
+        // Arrange
+        ResourceDictionary resourceDictionary1 = new(resourceDictionaryOptions); // Options as a class
+        ResourceDictionary resourceDictionary2 = new(options => options.Font = resourceDictionaryOptions.Font); // Options as a delegate
+
+        // Act
+        string actualContent1 = resourceDictionary1.Content;
+        string actualContent2 = resourceDictionary2.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent1);
+        Assert.Equal(expectedContent, actualContent2);
+    }
+}
+
+internal static class ResourceDictionaryTestsDataGenerator
+{
+    public static IEnumerable<object[]> ResourceDictionary_Content_TestCases()
+    {
+        yield return new object[]
+        {
+            new ResourceDictionaryOptions
+            {
+                Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
+                {
+                    { "F5", StandardFonts.TimesRoman.ToPdfIndirect(6).ToPdfIndirectIdentifier() },
+                    { "F6", StandardFonts.TimesRoman.ToPdfIndirect(8).ToPdfIndirectIdentifier() },
+                    { "F7", StandardFonts.TimesRoman.ToPdfIndirect(10).ToPdfIndirectIdentifier() },
+                    { "F8", StandardFonts.TimesRoman.ToPdfIndirect(12).ToPdfIndirectIdentifier() },
+                }.ToPdfDictionary()
+            },
+            "<</Font <</F5 6 0 R /F6 8 0 R /F7 10 0 R /F8 12 0 R>>>>"
+        };
+    }
+}

--- a/tools/code-coverage.bat
+++ b/tools/code-coverage.bat
@@ -1,2 +1,1 @@
 Powershell.exe -executionpolicy unrestricted -File %~dp0\code-coverage.ps1
-pause

--- a/tools/code-coverage.ps1
+++ b/tools/code-coverage.ps1
@@ -1,16 +1,26 @@
 Set-Location $PSScriptRoot\..
 
-dotnet test --collect:"XPlat Code Coverage"
+try {
+    dotnet test --collect:"XPlat Code Coverage"
 
-$test_projects = ("tests\Off.Net.Pdf.Core.Tests\")
+    $test_projects = ("tests\Off.Net.Pdf.Core.Tests\")
 
-foreach ($test_project in $test_projects) {
-    $test_report_folder_object = Get-ChildItem "$test_project\TestResults" | Where-Object { $_.PSIsContainer } | Sort-Object CreationTime -desc | Select-Object -f 1
-    $test_report_folder_name = $test_report_folder_object.PSChildName
-    dotnet tool run reportgenerator `
-    -reports:"$test_project\TestResults\$test_report_folder_name\coverage.cobertura.xml" `
-    -targetdir:"coveragereport" `
-    -reporttypes:Html
+    foreach ($test_project in $test_projects) {
+        $test_report_folder_object = Get-ChildItem "$test_project\TestResults" | Where-Object { $_.PSIsContainer } | Sort-Object CreationTime -desc | Select-Object -f 1
+        $test_report_folder_name = $test_report_folder_object.PSChildName
+        dotnet tool run reportgenerator `
+        -reports:"$test_project\TestResults\$test_report_folder_name\coverage.cobertura.xml" `
+        -targetdir:"coveragereport" `
+        -reporttypes:Html
+    }
+
+    Invoke-Item '.\coveragereport\index.html'
 }
+catch {
+    Write-Error "An error occurred: $_. Press any key to continue or Ctrl+C to exit."
+    $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown") | Out-Null
 
-Invoke-Item '.\coveragereport\index.html'
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.8.3`, a content stream’s named resources shall be defined by a `resource dictionary`, which shall enumerate the named resources needed by the operators in the content stream and the names by which they can be referred to.

Since there is no possibility to use indirect objects inside a content stream (i.e. fonts), the solution is to assign a meaningful name in the resource dictionary and use this name in the content stream itself.

This story will focus only on supporting the `Font` dictionary key, which is crucial to build a `hello world` PDF file.

Example of Resource Dictionary:

```
<</ProcSet [/PDF /ImageB]
  /Font <<
    /F5 6 0 R
    /F6 8 0 R
    /F7 10 0 R
    /F8 12 0 R
  >>
  /XObject <<
    /Im1 13 0 R
    /Im2 15 0 R
  >>
>>
```

### Acceptance criteria
1. The Resource dictionary must support the following key:
   | Key | Type | Notes |
   | --- | --- | --- |
   | Font | dictionary | Indirect reference, only Type1 font at this stage<br>#155 |
2. The page object must extend the #9
2. The code must be covered with the unit tests

