### PR TITLE
feat(document-structure): added basic page object

### DIFF
--- a/src/Off.Net.Pdf.Core/CommonDataStructures/Rectangle.cs
+++ b/src/Off.Net.Pdf.Core/CommonDataStructures/Rectangle.cs
@@ -3,7 +3,7 @@ using Off.Net.Pdf.Core.Primitives;
 
 namespace Off.Net.Pdf.Core.CommonDataStructures;
 
-public class Rectangle : PdfArray<PdfInteger>
+public sealed class Rectangle : PdfArray<PdfInteger>
 {
     #region Constructors
 

--- a/src/Off.Net.Pdf.Core/DocumentStructure/PageObject.cs
+++ b/src/Off.Net.Pdf.Core/DocumentStructure/PageObject.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.ObjectModel;
+using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.DocumentStructure;
+
+public sealed class PageObject : PdfDictionary<IPdfObject>
+{
+    #region Fields
+
+    private static readonly PdfName TypeName = new("Type");
+    private static readonly PdfName TypeValue = new("Page");
+    private static readonly PdfName Parent = new("Parent");
+    private static readonly PdfName Resources = new("Resources");
+    private static readonly PdfName MediaBox = new("MediaBox");
+
+    #endregion
+
+    #region Constructors
+
+    public PageObject(Action<PageObjectOptions> optionsFunc) : this(GetPageObjectOptions(optionsFunc))
+    {
+    }
+
+    public PageObject(PageObjectOptions options) : base(GenerateDictionary(options))
+    {
+        options.NotNull(x => x.Parent);
+        options.NotNull(x => x.Resources);
+        options.NotNull(x => x.MediaBox);
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private static PageObjectOptions GetPageObjectOptions(Action<PageObjectOptions> optionsFunc)
+    {
+        PageObjectOptions fileTrailerOptions = new();
+        optionsFunc.Invoke(fileTrailerOptions);
+        return fileTrailerOptions;
+    }
+
+    private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(PageObjectOptions options)
+    {
+        IDictionary<PdfName, IPdfObject> documentCatalogDictionary = new Dictionary<PdfName, IPdfObject>(4)
+            .WithKeyValue(TypeName, TypeValue)
+            .WithKeyValue(Parent, options.Parent)
+            .WithKeyValue(Resources, options.Resources)
+            .WithKeyValue(MediaBox, options.MediaBox);
+
+        return new ReadOnlyDictionary<PdfName, IPdfObject>(documentCatalogDictionary);
+    }
+
+    #endregion
+}
+
+public sealed class PageObjectOptions
+{
+    public PdfIndirectIdentifier<PdfNull> Parent { get; set; } = default!; // TODO: convert to page tree node once it's implemented
+
+    public ResourceDictionary Resources { get; set; } = default!;
+
+    public Rectangle MediaBox { get; set; } = default!;
+}

--- a/src/Off.Net.Pdf.Core/Extensions/GuardClauses.cs
+++ b/src/Off.Net.Pdf.Core/Extensions/GuardClauses.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Off.Net.Pdf.Core.Extensions;
 

--- a/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/DocumentCatalogTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/DocumentCatalogTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Off.Net.Pdf.Core.DocumentStructure;
+﻿using Off.Net.Pdf.Core.DocumentStructure;
 using Off.Net.Pdf.Core.Interfaces;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;

--- a/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageObjectTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageObjectTests.cs
@@ -1,0 +1,95 @@
+﻿using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.DocumentStructure;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text.Fonts;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.DocumentStructure;
+
+public class PageObjectTests
+{
+    [Fact(DisplayName = $"Constructor with a null {nameof(PageObjectOptions.Parent)} indirect reference should throw an {nameof(ArgumentNullException)}")]
+    public void PageObject_ConstructorWithNullParent_ShouldThrowException()
+    {
+        // Arrange
+        PageObjectOptions documentCatalogOptions = new() { Parent = null! };
+
+        // Act
+        PageObject PageObjectFunction() => new(documentCatalogOptions);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(PageObjectFunction);
+    }
+
+    [Fact(DisplayName = $"Constructor with a null {nameof(PageObjectOptions.Resources)} indirect reference should throw an {nameof(ArgumentNullException)}")]
+    public void PageObject_ConstructorWithNullResourceDictionary_ShouldThrowException()
+    {
+        // Arrange
+        PageObjectOptions documentCatalogOptions = new() { Parent = new PdfNull().ToPdfIndirect(1).ToPdfIndirectIdentifier(), Resources = null! };
+
+        // Act
+        PageObject PageObjectFunction() => new(documentCatalogOptions);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(PageObjectFunction);
+    }
+
+    [Fact(DisplayName = $"Constructor with a null {nameof(PageObjectOptions.MediaBox)} indirect reference should throw an {nameof(ArgumentNullException)}")]
+    public void PageObject_ConstructorWithNullMediaBox_ShouldThrowException()
+    {
+        // Arrange
+        ResourceDictionary resourceDictionary = new(new ResourceDictionaryOptions());
+        PageObjectOptions documentCatalogOptions = new() { Parent = new PdfNull().ToPdfIndirect(1).ToPdfIndirectIdentifier(), Resources = resourceDictionary, MediaBox = null! };
+
+        // Act
+        PageObject PageObjectFunction() => new(documentCatalogOptions);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(PageObjectFunction);
+    }
+
+    [Theory(DisplayName = $"The {nameof(PageObject.Content)} property should return a valid value")]
+    [MemberData(nameof(PageObjectTestsDataGenerator.PageObject_Content_TestCases), MemberType = typeof(PageObjectTestsDataGenerator))]
+    public void PageObject_Content_ShouldReturnValidValue(PageObjectOptions pageObjectOptions, string expectedContent)
+    {
+        // Arrange
+        PageObject pageObject1 = new(pageObjectOptions); // Options as a class
+        PageObject pageObject2 = new(options =>
+        {
+            options.Parent = pageObjectOptions.Parent;
+            options.Resources = pageObjectOptions.Resources;
+            options.MediaBox = pageObjectOptions.MediaBox;
+        }); // Options as a delegate
+
+        // Act
+        string actualContent1 = pageObject1.Content;
+        string actualContent2 = pageObject2.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent1);
+        Assert.Equal(expectedContent, actualContent2);
+    }
+}
+
+internal static class PageObjectTestsDataGenerator
+{
+    public static IEnumerable<object[]> PageObject_Content_TestCases()
+    {
+        yield return new object[]
+        {
+            new PageObjectOptions
+            {
+                Parent = new PdfNull().ToPdfIndirect(4).ToPdfIndirectIdentifier(),
+                Resources = new ResourceDictionary(options => options.Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
+                {
+                    { "F3", StandardFonts.TimesRoman.ToPdfIndirect(7).ToPdfIndirectIdentifier() },
+                    { "F5", StandardFonts.TimesRoman.ToPdfIndirect(9).ToPdfIndirectIdentifier() },
+                    { "F7", StandardFonts.TimesRoman.ToPdfIndirect(11).ToPdfIndirectIdentifier() },
+                }.ToPdfDictionary()),
+                MediaBox = new Rectangle(0, 0, 612, 792),
+            },
+            "<</Type /Page /Parent 4 0 R /Resources <</Font <</F3 7 0 R /F5 9 0 R /F7 11 0 R>>>> /MediaBox [0 0 612 792]>>"
+        };
+    }
+}

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/FileHeaderTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/FileHeaderTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Off.Net.Pdf.Core.FileStructure;
+﻿using Off.Net.Pdf.Core.FileStructure;
 using Xunit;
 
 namespace Off.Net.Pdf.Core.Tests.FileStructure;

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Off.Net.Pdf.Core.FileStructure;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSectionTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSectionTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Off.Net.Pdf.Core.FileStructure;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefSubSectionTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Off.Net.Pdf.Core.FileStructure;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefTableTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefTableTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Off.Net.Pdf.Core.FileStructure;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfArrayTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Off.Net.Pdf.Core.Interfaces;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfBooleanTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfDictionaryTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Off.Net.Pdf.Core.Interfaces;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectIdentifierTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectIdentifierTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Off.Net.Pdf.Core.Primitives;
+﻿using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 
 namespace Off.Net.Pdf.Core.Tests.Primitives;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIndirectTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Off.Net.Pdf.Core.Primitives;
+﻿using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 
 namespace Off.Net.Pdf.Core.Tests.Primitives;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfIntegerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNameTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfNullTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfRealTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;
 

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStreamTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using Off.Net.Pdf.Core.Interfaces;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;

--- a/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Primitives/PdfStringTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 using Off.Net.Pdf.Core.Primitives;
 using Xunit;


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.7.3`, The pages of a document are accessed through a structure known as the `page tree`, which defines the ordering of pages in the document. 

The tree contains nodes of two types — intermediate nodes, called `page tree nodes` (light blue), and leaf nodes, called `page objects` (purple).

```mermaid
graph TD;
    Root[Root Page Tree node]:::tree_node -->ChildNode1[Intermediate Node 1]:::tree_node;
    Root[Root Page Tree node]-->ChildNode2[Intermediate Node 2]:::tree_node;
    ChildNode1-->Page1[Page1]:::tree_leaf
    ChildNode1-->Page2[Page2]:::tree_leaf
    ChildNode2-->Page3[Page3]:::tree_leaf
    ChildNode2-->Page4[Page4]:::tree_leaf
    classDef tree_node fill:#03a9f4
    classDef tree_leaf fill:#673ab7
```

Example of Page Tree:

```
3 0 obj
  << /Type /Page
    /Parent 4 0 R
    /MediaBox [0 0 612 792]
    /Resources << 
      /Font <<
        /F3 7 0 R
        /F5 9 0 R
        /F7 11 0 R
      >>
    /ProcSet [/PDF]
  >>
  /Contents 12 0 R
  /Thumb 14 0 R
  /Annots [
    23 0 R
    24 0 R
  ]
  >>
endobj
```

### Acceptance criteria
1. Page Object should support the following required keys:
   | Key | Type | Deps |
   | --- | --- | --- |
   | Type | name | |
   | Parent | dictionary |  |
   | Resources | dictionary | #67 |
   | MediaBox | rectangle | #68 <br> #69 |
2. The page object must extend the #9
2. The code must be covered with the unit tests

