### PR TITLE
feat(document-structure): added basic page tree node

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# ReSharper properties
+resharper_max_initializer_elements_on_line = 1
+resharper_wrap_array_initializer_style = chop_if_long
+
 [*.cs]
 indent_size = 4
 dotnet_sort_system_directives_first = true
@@ -86,247 +90,247 @@ charset = utf-8-bom
 [*.{cs,vb}]
 
 # CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = warning
+dotnet_diagnostic.ca1018.severity = warning
 
 # CA1047: Do not declare protected member in sealed type
-dotnet_diagnostic.CA1047.severity = warning
+dotnet_diagnostic.ca1047.severity = warning
 
 # CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.ca1305.severity = warning
 
 # CA1507: Use nameof to express symbol names
-dotnet_diagnostic.CA1507.severity = warning
+dotnet_diagnostic.ca1507.severity = warning
 
 # CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1725.severity = suggestion
+dotnet_diagnostic.ca1725.severity = suggestion
 
 # CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.ca1802.severity = warning
 
 # CA1805: Do not initialize unnecessarily
-dotnet_diagnostic.CA1805.severity = warning
+dotnet_diagnostic.ca1805.severity = warning
 
 # CA1810: Do not initialize unnecessarily
-dotnet_diagnostic.CA1810.severity = warning
+dotnet_diagnostic.ca1810.severity = warning
 
 # CA1821: Remove empty Finalizers
-dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.ca1821.severity = warning
 
 # CA1822: Make member static
-dotnet_diagnostic.CA1822.severity = warning
-dotnet_code_quality.CA1822.api_surface = private, internal
+dotnet_diagnostic.ca1822.severity = warning
+dotnet_code_quality.ca1822.api_surface = private, internal
 
 # CA1823: Avoid unused private fields
-dotnet_diagnostic.CA1823.severity = warning
+dotnet_diagnostic.ca1823.severity = warning
 
 # CA1825: Avoid zero-length array allocations
-dotnet_diagnostic.CA1825.severity = warning
+dotnet_diagnostic.ca1825.severity = warning
 
 # CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
-dotnet_diagnostic.CA1826.severity = warning
+dotnet_diagnostic.ca1826.severity = warning
 
 # CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = warning
+dotnet_diagnostic.ca1827.severity = warning
 
 # CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-dotnet_diagnostic.CA1828.severity = warning
+dotnet_diagnostic.ca1828.severity = warning
 
 # CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1829.severity = warning
+dotnet_diagnostic.ca1829.severity = warning
 
 # CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-dotnet_diagnostic.CA1830.severity = warning
+dotnet_diagnostic.ca1830.severity = warning
 
 # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 # CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1831.severity = warning
-dotnet_diagnostic.CA1832.severity = warning
-dotnet_diagnostic.CA1833.severity = warning
+dotnet_diagnostic.ca1831.severity = warning
+dotnet_diagnostic.ca1832.severity = warning
+dotnet_diagnostic.ca1833.severity = warning
 
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
-dotnet_diagnostic.CA1834.severity = warning
+dotnet_diagnostic.ca1834.severity = warning
 
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-dotnet_diagnostic.CA1835.severity = warning
+dotnet_diagnostic.ca1835.severity = warning
 
 # CA1836: Prefer IsEmpty over Count
-dotnet_diagnostic.CA1836.severity = warning
+dotnet_diagnostic.ca1836.severity = warning
 
 # CA1837: Use 'Environment.ProcessId'
-dotnet_diagnostic.CA1837.severity = warning
+dotnet_diagnostic.ca1837.severity = warning
 
 # CA1838: Avoid 'StringBuilder' parameters for P/Invokes
-dotnet_diagnostic.CA1838.severity = warning
+dotnet_diagnostic.ca1838.severity = warning
 
 # CA1839: Use 'Environment.ProcessPath'
-dotnet_diagnostic.CA1839.severity = warning
+dotnet_diagnostic.ca1839.severity = warning
 
 # CA1840: Use 'Environment.CurrentManagedThreadId'
-dotnet_diagnostic.CA1840.severity = warning
+dotnet_diagnostic.ca1840.severity = warning
 
 # CA1841: Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1841.severity = warning
+dotnet_diagnostic.ca1841.severity = warning
 
 # CA1842: Do not use 'WhenAll' with a single task
-dotnet_diagnostic.CA1842.severity = warning
+dotnet_diagnostic.ca1842.severity = warning
 
 # CA1843: Do not use 'WaitAll' with a single task
-dotnet_diagnostic.CA1843.severity = warning
+dotnet_diagnostic.ca1843.severity = warning
 
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1844.severity = warning
+dotnet_diagnostic.ca1844.severity = warning
 
 # CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = warning
+dotnet_diagnostic.ca1845.severity = warning
 
 # CA1846: Prefer AsSpan over Substring
-dotnet_diagnostic.CA1846.severity = warning
+dotnet_diagnostic.ca1846.severity = warning
 
 # CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
-dotnet_diagnostic.CA1847.severity = warning
+dotnet_diagnostic.ca1847.severity = warning
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = warning
+dotnet_diagnostic.ca2007.severity = warning
 
 # CA2008: Do not create tasks without passing a TaskScheduler
-dotnet_diagnostic.CA2008.severity = warning
+dotnet_diagnostic.ca2008.severity = warning
 
 # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-dotnet_diagnostic.CA2009.severity = warning
+dotnet_diagnostic.ca2009.severity = warning
 
 # CA2011: Avoid infinite recursion
-dotnet_diagnostic.CA2011.severity = warning
+dotnet_diagnostic.ca2011.severity = warning
 
 # CA2012: Use ValueTask correctly
-dotnet_diagnostic.CA2012.severity = warning
+dotnet_diagnostic.ca2012.severity = warning
 
 # CA2013: Do not use ReferenceEquals with value types
-dotnet_diagnostic.CA2013.severity = warning
+dotnet_diagnostic.ca2013.severity = warning
 
 # CA2014: Do not use stackalloc in loops.
-dotnet_diagnostic.CA2014.severity = warning
+dotnet_diagnostic.ca2014.severity = warning
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = warning
+dotnet_diagnostic.ca2016.severity = warning
 
 # CA2200: Rethrow to preserve stack details
-dotnet_diagnostic.CA2200.severity = warning
+dotnet_diagnostic.ca2200.severity = warning
 
 # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.ca2208.severity = warning
 
 # CA2245: Do not assign a property to itself
-dotnet_diagnostic.CA2245.severity = warning
+dotnet_diagnostic.ca2245.severity = warning
 
 # CA2246: Assigning symbol and its member in the same statement
-dotnet_diagnostic.CA2246.severity = warning
+dotnet_diagnostic.ca2246.severity = warning
 
 # CA2249: Use string.Contains instead of string.IndexOf to improve readability.
-dotnet_diagnostic.CA2249.severity = warning
+dotnet_diagnostic.ca2249.severity = warning
 
 # IDE0005: Remove unnecessary usings
-dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.ide0005.severity = warning
 
 # IDE0011: Curly braces to surround blocks of code
-dotnet_diagnostic.IDE0011.severity = warning
+dotnet_diagnostic.ide0011.severity = warning
 
 # IDE0035: Remove unreachable code
-dotnet_diagnostic.IDE0035.severity = warning
+dotnet_diagnostic.ide0035.severity = warning
 
 # IDE0036: Order modifiers
 csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
-dotnet_diagnostic.IDE0036.severity = warning
+dotnet_diagnostic.ide0036.severity = warning
 
 # IDE0043: Format string contains invalid placeholder
-dotnet_diagnostic.IDE0043.severity = warning
+dotnet_diagnostic.ide0043.severity = warning
 
 # IDE0044: Make field readonly
-dotnet_diagnostic.IDE0044.severity = warning
+dotnet_diagnostic.ide0044.severity = warning
 
 # IDE0051: Remove unused private members
-dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.ide0051.severity = warning
 
 # IDE0055: All formatting rules
-dotnet_diagnostic.IDE0055.severity = suggestion
+dotnet_diagnostic.ide0055.severity = suggestion
 
 # IDE0059: Unnecessary assignment to a value
-dotnet_diagnostic.IDE0059.severity = warning
+dotnet_diagnostic.ide0059.severity = warning
 
 # IDE0060: Remove unused parameter
 dotnet_code_quality_unused_parameters = non_public
-dotnet_diagnostic.IDE0060.severity = warning
+dotnet_diagnostic.ide0060.severity = warning
 
 # IDE0062: Make local function static
-dotnet_diagnostic.IDE0062.severity = warning
+dotnet_diagnostic.ide0062.severity = warning
 
 # IDE0161: Convert to file-scoped namespace
-dotnet_diagnostic.IDE0161.severity = warning
+dotnet_diagnostic.ide0161.severity = warning
 
 # IDE2000: Disallow multiple blank lines
 dotnet_style_allow_multiple_blank_lines_experimental = false
-dotnet_diagnostic.IDE2000.severity = warning
+dotnet_diagnostic.ide2000.severity = warning
 
 [{eng/tools/**.cs, **/{test,testassets,samples,Samples,perf}/**.cs}]
 # CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = suggestion
+dotnet_diagnostic.ca1018.severity = suggestion
 # CA1507: Use nameof to express symbol names
-dotnet_diagnostic.CA1507.severity = suggestion
+dotnet_diagnostic.ca1507.severity = suggestion
 # CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = suggestion
+dotnet_diagnostic.ca1802.severity = suggestion
 # CA1805: Do not initialize unnecessarily
-dotnet_diagnostic.CA1805.severity = suggestion
+dotnet_diagnostic.ca1805.severity = suggestion
 # CA1810: Do not initialize unnecessarily
-dotnet_diagnostic.CA1810.severity = suggestion
+dotnet_diagnostic.ca1810.severity = suggestion
 # CA1822: Make member static
-dotnet_diagnostic.CA1822.severity = suggestion
+dotnet_diagnostic.ca1822.severity = suggestion
 # CA1823: Avoid zero-length array allocations
-dotnet_diagnostic.CA1825.severity = suggestion
+dotnet_diagnostic.ca1825.severity = suggestion
 # CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
-dotnet_diagnostic.CA1826.severity = suggestion
+dotnet_diagnostic.ca1826.severity = suggestion
 # CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = suggestion
+dotnet_diagnostic.ca1827.severity = suggestion
 # CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1829.severity = suggestion
+dotnet_diagnostic.ca1829.severity = suggestion
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
-dotnet_diagnostic.CA1834.severity = suggestion
+dotnet_diagnostic.ca1834.severity = suggestion
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-dotnet_diagnostic.CA1835.severity = suggestion
+dotnet_diagnostic.ca1835.severity = suggestion
 # CA1837: Use 'Environment.ProcessId'
-dotnet_diagnostic.CA1837.severity = suggestion
+dotnet_diagnostic.ca1837.severity = suggestion
 # CA1838: Avoid 'StringBuilder' parameters for P/Invokes
-dotnet_diagnostic.CA1838.severity = suggestion
+dotnet_diagnostic.ca1838.severity = suggestion
 # CA1841: Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1841.severity = suggestion
+dotnet_diagnostic.ca1841.severity = suggestion
 # CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1844.severity = suggestion
+dotnet_diagnostic.ca1844.severity = suggestion
 # CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = suggestion
+dotnet_diagnostic.ca1845.severity = suggestion
 # CA1846: Prefer AsSpan over Substring
-dotnet_diagnostic.CA1846.severity = suggestion
+dotnet_diagnostic.ca1846.severity = suggestion
 # CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
-dotnet_diagnostic.CA1847.severity = suggestion
+dotnet_diagnostic.ca1847.severity = suggestion
 # CA2008: Do not create tasks without passing a TaskScheduler
-dotnet_diagnostic.CA2008.severity = suggestion
+dotnet_diagnostic.ca2008.severity = suggestion
 # CA2012: Use ValueTask correctly
-dotnet_diagnostic.CA2012.severity = suggestion
+dotnet_diagnostic.ca2012.severity = suggestion
 # CA2249: Use string.Contains instead of string.IndexOf to improve readability.
-dotnet_diagnostic.CA2249.severity = suggestion
+dotnet_diagnostic.ca2249.severity = suggestion
 # IDE0005: Remove unnecessary usings
-dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.ide0005.severity = suggestion
 # IDE0044: Make field readonly
-dotnet_diagnostic.IDE0044.severity = suggestion
+dotnet_diagnostic.ide0044.severity = suggestion
 # IDE0051: Remove unused private members
-dotnet_diagnostic.IDE0051.severity = suggestion
+dotnet_diagnostic.ide0051.severity = suggestion
 # IDE0059: Unnecessary assignment to a value
-dotnet_diagnostic.IDE0059.severity = suggestion
+dotnet_diagnostic.ide0059.severity = suggestion
 # IDE0060: Remove unused parameters
-dotnet_diagnostic.IDE0060.severity = suggestion
+dotnet_diagnostic.ide0060.severity = suggestion
 # IDE0062: Make local function static
-dotnet_diagnostic.IDE0062.severity = suggestion
+dotnet_diagnostic.ide0062.severity = suggestion
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = suggestion
+dotnet_diagnostic.ca2016.severity = suggestion
 
 [*.{cs,vb}]
 #### Naming styles ####

--- a/src/Off.Net.Pdf.Core/DocumentStructure/DocumentCatalog.cs
+++ b/src/Off.Net.Pdf.Core/DocumentStructure/DocumentCatalog.cs
@@ -34,9 +34,9 @@ public sealed class DocumentCatalog : PdfDictionary<IPdfObject>
 
     private static DocumentCatalogOptions GetDocumentCatalogOptions(Action<DocumentCatalogOptions> optionsFunc)
     {
-        DocumentCatalogOptions fileTrailerOptions = new();
-        optionsFunc.Invoke(fileTrailerOptions);
-        return fileTrailerOptions;
+        DocumentCatalogOptions options = new();
+        optionsFunc.Invoke(options);
+        return options;
     }
 
     private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(DocumentCatalogOptions options)

--- a/src/Off.Net.Pdf.Core/DocumentStructure/PageObject.cs
+++ b/src/Off.Net.Pdf.Core/DocumentStructure/PageObject.cs
@@ -28,9 +28,6 @@ public sealed class PageObject : PdfDictionary<IPdfObject>
 
     public PageObject(PageObjectOptions options) : base(GenerateDictionary(options))
     {
-        options.NotNull(x => x.Parent);
-        options.NotNull(x => x.Resources);
-        options.NotNull(x => x.MediaBox);
     }
 
     #endregion
@@ -39,13 +36,17 @@ public sealed class PageObject : PdfDictionary<IPdfObject>
 
     private static PageObjectOptions GetPageObjectOptions(Action<PageObjectOptions> optionsFunc)
     {
-        PageObjectOptions fileTrailerOptions = new();
-        optionsFunc.Invoke(fileTrailerOptions);
-        return fileTrailerOptions;
+        PageObjectOptions options = new();
+        optionsFunc.Invoke(options);
+        return options;
     }
 
     private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(PageObjectOptions options)
     {
+        options.NotNull(x => x.Parent);
+        options.NotNull(x => x.Resources);
+        options.NotNull(x => x.MediaBox);
+
         IDictionary<PdfName, IPdfObject> documentCatalogDictionary = new Dictionary<PdfName, IPdfObject>(5)
             .WithKeyValue(TypeName, TypeValue)
             .WithKeyValue(Parent, options.Parent)
@@ -61,7 +62,7 @@ public sealed class PageObject : PdfDictionary<IPdfObject>
 
 public sealed class PageObjectOptions
 {
-    public PdfIndirectIdentifier<PdfNull> Parent { get; set; } = default!; // TODO: convert to page tree node once it's implemented
+    public PdfIndirectIdentifier<PageTreeNode> Parent { get; set; } = default!;
 
     public ResourceDictionary Resources { get; set; } = default!;
 

--- a/src/Off.Net.Pdf.Core/DocumentStructure/PageTreeNode.cs
+++ b/src/Off.Net.Pdf.Core/DocumentStructure/PageTreeNode.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.ObjectModel;
+using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.Extensions;
+using Off.Net.Pdf.Core.Interfaces;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Core.DocumentStructure;
+
+public sealed class PageTreeNode : PdfDictionary<IPdfObject>
+{
+    #region Fields
+
+    private static readonly PdfName TypeName = "Type";
+    private static readonly PdfName TypeValue = "Pages";
+    private static readonly PdfName Parent = "Parent";
+    private static readonly PdfName Kids = "Kids";
+    private static readonly PdfName Count = "Count";
+
+    #endregion
+
+    #region Constructors
+
+    public PageTreeNode(Action<PageTreeNodeOptions> optionsFunc) : this(GetPageTreeNodeOptions(optionsFunc))
+    {
+    }
+
+    public PageTreeNode(PageTreeNodeOptions options) : base(GenerateDictionary(options))
+    {
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    private static PageTreeNodeOptions GetPageTreeNodeOptions(Action<PageTreeNodeOptions> optionsFunc)
+    {
+        PageTreeNodeOptions options = new();
+        optionsFunc.Invoke(options);
+        return options;
+    }
+
+    private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(PageTreeNodeOptions options)
+    {
+        options.NotNull(x => x.Kids);
+
+        IDictionary<PdfName, IPdfObject> documentCatalogDictionary = new Dictionary<PdfName, IPdfObject>(4)
+            .WithKeyValue(TypeName, TypeValue)
+            .WithKeyValue(Parent, options.Parent)
+            .WithKeyValue(Kids, options.Kids)
+            .WithKeyValue(Count, (PdfInteger)options.Kids.Value.Count);
+
+        return new ReadOnlyDictionary<PdfName, IPdfObject>(documentCatalogDictionary);
+    }
+
+    #endregion
+}
+
+public sealed class PageTreeNodeOptions
+{
+    public PdfIndirectIdentifier<PageTreeNode>? Parent { get; set; }
+
+    public PdfArray<PdfIndirectIdentifier<PageObject>> Kids { get; set; } = default!;
+}

--- a/src/Off.Net.Pdf.Core/Text/Fonts/Type1Font.cs
+++ b/src/Off.Net.Pdf.Core/Text/Fonts/Type1Font.cs
@@ -35,9 +35,9 @@ public sealed class Type1Font : PdfDictionary<IPdfObject>
 
     private static Type1FontOptions GetType1FontOptions(Action<Type1FontOptions> optionsFunc)
     {
-        Type1FontOptions fileTrailerOptions = new();
-        optionsFunc.Invoke(fileTrailerOptions);
-        return fileTrailerOptions;
+        Type1FontOptions options = new();
+        optionsFunc.Invoke(options);
+        return options;
     }
 
     private static IReadOnlyDictionary<PdfName, IPdfObject> GenerateDictionary(Type1FontOptions options)

--- a/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageObjectTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageObjectTests.cs
@@ -26,7 +26,11 @@ public class PageObjectTests
     public void PageObject_ConstructorWithNullResourceDictionary_ShouldThrowException()
     {
         // Arrange
-        PageObjectOptions documentCatalogOptions = new() { Parent = new PdfNull().ToPdfIndirect(1).ToPdfIndirectIdentifier(), Resources = null! };
+        PdfIndirectIdentifier<PageTreeNode> parent = new PageTreeNode(options => options.Kids = Array.Empty<PdfIndirectIdentifier<PageObject>>().ToPdfArray())
+            .ToPdfIndirect(1)
+            .ToPdfIndirectIdentifier();
+
+        PageObjectOptions documentCatalogOptions = new() { Parent = parent, Resources = null! };
 
         // Act
         PageObject PageObjectFunction() => new(documentCatalogOptions);
@@ -39,8 +43,12 @@ public class PageObjectTests
     public void PageObject_ConstructorWithNullMediaBox_ShouldThrowException()
     {
         // Arrange
+        PdfIndirectIdentifier<PageTreeNode> parent = new PageTreeNode(options => options.Kids = Array.Empty<PdfIndirectIdentifier<PageObject>>().ToPdfArray())
+            .ToPdfIndirect(1)
+            .ToPdfIndirectIdentifier();
+
         ResourceDictionary resourceDictionary = new(new ResourceDictionaryOptions());
-        PageObjectOptions documentCatalogOptions = new() { Parent = new PdfNull().ToPdfIndirect(1).ToPdfIndirectIdentifier(), Resources = resourceDictionary, MediaBox = null! };
+        PageObjectOptions documentCatalogOptions = new() { Parent = parent, Resources = resourceDictionary, MediaBox = null! };
 
         // Act
         PageObject PageObjectFunction() => new(documentCatalogOptions);
@@ -77,11 +85,13 @@ internal static class PageObjectTestsDataGenerator
 {
     public static IEnumerable<object[]> PageObject_Content_TestCases()
     {
+        PageTreeNode parent = new(options => options.Kids = Array.Empty<PdfIndirectIdentifier<PageObject>>().ToPdfArray());
+
         yield return new object[]
         {
             new PageObjectOptions
             {
-                Parent = new PdfNull().ToPdfIndirect(4).ToPdfIndirectIdentifier(),
+                Parent = parent.ToPdfIndirect(4).ToPdfIndirectIdentifier(),
                 Resources = new ResourceDictionary(options => options.Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
                 {
                     { "F3", StandardFonts.TimesRoman.ToPdfIndirect(7).ToPdfIndirectIdentifier() },
@@ -96,7 +106,7 @@ internal static class PageObjectTestsDataGenerator
         {
             new PageObjectOptions
             {
-                Parent = new PdfNull().ToPdfIndirect(4).ToPdfIndirectIdentifier(),
+                Parent = parent.ToPdfIndirect(3).ToPdfIndirectIdentifier(),
                 Resources = new ResourceDictionary(options => options.Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
                 {
                     { "F3", StandardFonts.TimesRoman.ToPdfIndirect(7).ToPdfIndirectIdentifier() },
@@ -104,9 +114,9 @@ internal static class PageObjectTestsDataGenerator
                     { "F7", StandardFonts.TimesRoman.ToPdfIndirect(11).ToPdfIndirectIdentifier() },
                 }.ToPdfDictionary()),
                 MediaBox = new Rectangle(0, 0, 612, 792),
-                Contents = new PdfStream("".AsMemory()).ToPdfIndirect(4,2).ToPdfIndirectIdentifier()
+                Contents = new PdfStream("".AsMemory()).ToPdfIndirect(4, 2).ToPdfIndirectIdentifier()
             },
-            "<</Type /Page /Parent 4 0 R /Resources <</Font <</F3 7 0 R /F5 9 0 R /F7 11 0 R>> /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]>> /MediaBox [0 0 612 792] /Contents 4 2 R>>"
+            "<</Type /Page /Parent 3 0 R /Resources <</Font <</F3 7 0 R /F5 9 0 R /F7 11 0 R>> /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]>> /MediaBox [0 0 612 792] /Contents 4 2 R>>"
         };
     }
 }

--- a/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageTreeNodeTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/PageTreeNodeTests.cs
@@ -1,0 +1,108 @@
+﻿using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.DocumentStructure;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text.Fonts;
+using Xunit;
+
+namespace Off.Net.Pdf.Core.Tests.DocumentStructure;
+
+public class PageTreeNodeTests
+{
+    [Fact(DisplayName = $"Constructor with a null {nameof(PageTreeNodeOptions.Kids)} indirect reference should throw an {nameof(ArgumentNullException)}")]
+    public void PageTreeNode_ConstructorWithNullParent_ShouldThrowException()
+    {
+        // Arrange
+        PageTreeNodeOptions pageTreeNodeOptions = new() { Kids = null! };
+
+        // Act
+        PageTreeNode PageTreeNodeFunction() => new(pageTreeNodeOptions);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(PageTreeNodeFunction);
+    }
+
+    [Theory(DisplayName = $"The {nameof(PageTreeNode.Content)} property should return a valid value")]
+    [MemberData(nameof(PageTreeNodeTestsDataGenerator.PageTreeNode_Content_TestCases), MemberType = typeof(PageTreeNodeTestsDataGenerator))]
+    public void PageTreeNode_Content_ShouldReturnValidValue(PageTreeNodeOptions pageObjectOptions, string expectedContent)
+    {
+        // Arrange
+        PageTreeNode pageObject1 = new(pageObjectOptions); // Options as a class
+        PageTreeNode pageObject2 = new(options =>
+        {
+            options.Parent = pageObjectOptions.Parent;
+            options.Kids = pageObjectOptions.Kids;
+        }); // Options as a delegate
+
+        // Act
+        string actualContent1 = pageObject1.Content;
+        string actualContent2 = pageObject2.Content;
+
+        // Assert
+        Assert.Equal(expectedContent, actualContent1);
+        Assert.Equal(expectedContent, actualContent2);
+    }
+}
+
+internal static class PageTreeNodeTestsDataGenerator
+{
+    public static IEnumerable<object[]> PageTreeNode_Content_TestCases()
+    {
+        PageObjectOptions pageObjectOptions = new()
+        {
+            Parent = new PageTreeNode(options => options.Kids = Array.Empty<PdfIndirectIdentifier<PageObject>>().ToPdfArray()).ToPdfIndirect(3, 6).ToPdfIndirectIdentifier(),
+            Resources = new ResourceDictionary(options => options.Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
+            {
+                { "F3", StandardFonts.TimesRoman.ToPdfIndirect(7).ToPdfIndirectIdentifier() },
+                { "F5", StandardFonts.TimesRoman.ToPdfIndirect(9).ToPdfIndirectIdentifier() },
+                { "F7", StandardFonts.TimesRoman.ToPdfIndirect(11).ToPdfIndirectIdentifier() },
+            }.ToPdfDictionary()),
+            MediaBox = new Rectangle(0, 0, 612, 792),
+        };
+
+        yield return new object[]
+        {
+            new PageTreeNodeOptions { Kids = new[] { new PageObject(pageObjectOptions).ToPdfIndirect(5, 3).ToPdfIndirectIdentifier() }.ToPdfArray() }, "<</Type /Pages /Kids [5 3 R] /Count 1>>"
+        };
+        yield return new object[]
+        {
+            new PageTreeNodeOptions
+            {
+                Kids = new[]
+                {
+                    new PageObject(pageObjectOptions).ToPdfIndirect(5, 3).ToPdfIndirectIdentifier(), new PageObject(pageObjectOptions).ToPdfIndirect(3, 1).ToPdfIndirectIdentifier()
+                }.ToPdfArray()
+            },
+            "<</Type /Pages /Kids [5 3 R 3 1 R] /Count 2>>"
+        };
+        yield return new object[]
+        {
+            new PageTreeNodeOptions
+            {
+                Kids = new[]
+                {
+                    new PageObject(pageObjectOptions).ToPdfIndirect(5, 3).ToPdfIndirectIdentifier(),
+                    new PageObject(pageObjectOptions).ToPdfIndirect(3, 1).ToPdfIndirectIdentifier(),
+                    new PageObject(pageObjectOptions).ToPdfIndirect(12, 6).ToPdfIndirectIdentifier()
+                }.ToPdfArray()
+            },
+            "<</Type /Pages /Kids [5 3 R 3 1 R 12 6 R] /Count 3>>"
+        };
+        yield return new object[]
+        {
+            new PageTreeNodeOptions
+            {
+                Kids = new[]
+                {
+                    new PageObject(pageObjectOptions).ToPdfIndirect(5, 3).ToPdfIndirectIdentifier(),
+                    new PageObject(pageObjectOptions).ToPdfIndirect(3, 1).ToPdfIndirectIdentifier(),
+                    new PageObject(pageObjectOptions).ToPdfIndirect(12, 6).ToPdfIndirectIdentifier()
+                }.ToPdfArray(),
+                Parent = new PageTreeNode(options => options.Kids = new[] { new PageObject(pageObjectOptions).ToPdfIndirect(5, 3).ToPdfIndirectIdentifier() }.ToPdfArray())
+                    .ToPdfIndirect(8)
+                    .ToPdfIndirectIdentifier()
+            },
+            "<</Type /Pages /Parent 8 0 R /Kids [5 3 R 3 1 R 12 6 R] /Count 3>>"
+        };
+    }
+}


### PR DESCRIPTION
### Context

According to the `ISO 32000-1:2008` specification, section `7.7.3`, The pages of a document are accessed through a structure known as the `page tree`, which defines the ordering of pages in the document. 

The tree contains nodes of two types — intermediate nodes, called `page tree nodes` (light blue), and leaf nodes, called `page objects` (purple).

```mermaid
graph TD;
    Root[Root Page Tree node]:::tree_node -->ChildNode1[Intermediate Node 1]:::tree_node;
    Root[Root Page Tree node]-->ChildNode2[Intermediate Node 2]:::tree_node;
    ChildNode1-->Page1[Page1]:::tree_leaf
    ChildNode1-->Page2[Page2]:::tree_leaf
    ChildNode2-->Page3[Page3]:::tree_leaf
    ChildNode2-->Page4[Page4]:::tree_leaf
    classDef tree_node fill:#03a9f4
    classDef tree_leaf fill:#673ab7
```

Example of Page Tree Node:

```
2 0 obj
  << /Type /Pages
     /Kids [ 4 0 R
            10 0 R
            24 0 R
          ]
     /Count 3
  >>
endobj

```

### Acceptance criteria
1. Page Object should support the following required keys:
   | Key | Type | Notes |
   | --- | --- | --- |
   | Type | name | |
   | Parent | dictionary | |
   | Kids | array | |
   | Count | integer | |
2. The page object must extend the #9
3. The code must be covered with the unit tests