### PR TITLE
feat(document): added high-level PDF document generation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.15",
+      "version": "5.1.20",
       "commands": [
         "reportgenerator"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-stryker": {
-      "version": "3.7.1",
+      "version": "3.8.2",
       "commands": [
         "dotnet-stryker"
       ]

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,8 +45,9 @@ jobs:
     name: Sonar Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: ${{ !contains(github.event.head_commit.author.email, 'dependabot') || github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Cache NuGet modules
@@ -99,7 +100,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
       - name: Restore dependencies

--- a/.netconfig
+++ b/.netconfig
@@ -1,5 +1,5 @@
-[reportgenerator]
+[ReportGenerator]
 	reporttypes = Html
-    reports = src/Off.Net.Pdf.Core.Tests/TestResults/*/coverage.cobertura.xml
+    reports = "tests\\**\\TestResults\\**\\coverage.cobertura.xml"
 	targetdir = coveragereport
     historydir = coveragereport_history

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,17 +15,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.56.0.67649">
+    <PackageReference Include="SonarAnalyzer.CSharp">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Roslynator.Analyzers" Version="4.3.0">
+    <PackageReference Include="Roslynator.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="StyleCop.Analyzers " Version="1.2.0-beta.435">
+    <PackageReference Include="StyleCop.Analyzers">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,35 @@
+<Project>
+    <!-- Analyzers -->
+    <ItemGroup>
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.3.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+    </ItemGroup>
+    <!-- Test packages -->
+    <ItemGroup>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageVersion Include="xunit" Version="2.4.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+    </ItemGroup>
+    <!-- Benchmarking packages -->
+    <ItemGroup>
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+        <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+    </ItemGroup>
+</Project>

--- a/Off.Net.sln
+++ b/Off.Net.sln
@@ -17,9 +17,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		Directory.Build.props = Directory.Build.props
 		stylecop.json = stylecop.json
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{9AD1AB50-CB0F-43D9-B721-DE1572FC6875}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Off.Net.Pdf.Core.Tests", "tests\Off.Net.Pdf.Core.Tests\Off.Net.Pdf.Core.Tests.csproj", "{C09DDCF0-700D-46DA-BD9A-B3340E2E76B6}"
 EndProject
@@ -54,6 +58,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Off.Net.Pdf.Core.Benchmarks", "benchmarks\Off.Net.Pdf.Core.Benchmarks\Off.Net.Pdf.Core.Benchmarks.csproj", "{0D089F68-B320-4C77-B0EC-83515B4E2E22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Off.Net.Pdf.Document", "src\Off.Net.Pdf.Document\Off.Net.Pdf.Document.csproj", "{B4FE086C-3DC3-434B-A078-A3AEAB891BE4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Off.Net.Pdf.Document.Tests", "tests\Off.Net.Pdf.Document.Tests\Off.Net.Pdf.Document.Tests.csproj", "{9564929B-7B38-43F5-8248-E61D44B0F4EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Off.Net.Pdf.Console", "src\Off.Net.Pdf.Console\Off.Net.Pdf.Console.csproj", "{29953D43-1CE1-4B21-BD8C-A24B10DE5058}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +82,18 @@ Global
 		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D089F68-B320-4C77-B0EC-83515B4E2E22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4FE086C-3DC3-434B-A078-A3AEAB891BE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4FE086C-3DC3-434B-A078-A3AEAB891BE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4FE086C-3DC3-434B-A078-A3AEAB891BE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4FE086C-3DC3-434B-A078-A3AEAB891BE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9564929B-7B38-43F5-8248-E61D44B0F4EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9564929B-7B38-43F5-8248-E61D44B0F4EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9564929B-7B38-43F5-8248-E61D44B0F4EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9564929B-7B38-43F5-8248-E61D44B0F4EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29953D43-1CE1-4B21-BD8C-A24B10DE5058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29953D43-1CE1-4B21-BD8C-A24B10DE5058}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29953D43-1CE1-4B21-BD8C-A24B10DE5058}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29953D43-1CE1-4B21-BD8C-A24B10DE5058}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +105,7 @@ Global
 		{9BFC64AB-0E3C-4EE2-959E-7D5F0455ADC4} = {E5BBC6F7-E046-48B6-A870-D115644713DD}
 		{293A6DEE-237E-45F8-B770-717F6846A913} = {D587B5E1-06B4-4CA7-8FE4-62B0DF71BAD6}
 		{0D089F68-B320-4C77-B0EC-83515B4E2E22} = {F1BF62EB-6D20-45E2-8546-1BEDD3408AF2}
+		{9564929B-7B38-43F5-8248-E61D44B0F4EB} = {9AD1AB50-CB0F-43D9-B721-DE1572FC6875}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1C5CCEAE-E0B4-4074-9291-2AAD38F9117F}

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/Off.Net.Pdf.Core.Benchmarks.csproj
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/Off.Net.Pdf.Core.Benchmarks.csproj
@@ -14,8 +14,8 @@
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj" />

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/Program.cs
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/Program.cs
@@ -3,45 +3,14 @@
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>
 
-#if !DEBUG
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
-#endif
-
-#if DEBUG
-using Off.Net.Pdf.Core.Benchmarks;
-
-const int pagesCount = 10000;
-
-SimplePdfBenchmarks simplePdfBenchmarks = new();
-simplePdfBenchmarks.Setup();
-
-var stream = simplePdfBenchmarks.BasicPdfWithMultiplePagesAndDifferentContentStreams(pagesCount);
-
-if (stream == null)
-{
-    return;
-}
-
-string filePath = Path.Combine(Environment.CurrentDirectory, $"off.net-{pagesCount}.pdf");
-FileStream fileStream = new(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
-fileStream.SetLength(0);
-
-stream.Position = 0;
-await stream.CopyToAsync(fileStream).ConfigureAwait(false);
-await fileStream.DisposeAsync().ConfigureAwait(false);
-
-simplePdfBenchmarks.Cleanup();
-
-#else
 
 var config = DefaultConfig.Instance
     .AddDiagnoser(MemoryDiagnoser.Default)
     .AddLogger(ConsoleLogger.Default)
     .AddExporter(JsonExporter.Default);
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
-
-#endif

--- a/benchmarks/Off.Net.Pdf.Core.Benchmarks/packages.lock.json
+++ b/benchmarks/Off.Net.Pdf.Core.Benchmarks/packages.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "dependencies": {
     "net6.0": {
       "BenchmarkDotNet": {
@@ -38,9 +38,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.56.0.67649, )",
-        "resolved": "8.56.0.67649",
-        "contentHash": "u5klyn4PBAOe38/CoPbxGjuMqJQ5K0M7SA17H2DHgHyQ+neSU+abneRGjSQSVD76kbYXzG7E1/KQwTuj+nnMZw=="
+        "requested": "[9.0.0.68202, )",
+        "resolved": "9.0.0.68202",
+        "contentHash": "CdkFID8hrFCwxZkB/xubADWO0zZoGxG8fv6MHUoreUQ6syLXCELDE9DZy68ktEX1DhsQeW8IUHMroUU2gh2Byw=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",

--- a/src/Off.Net.Pdf.Console/Off.Net.Pdf.Console.csproj
+++ b/src/Off.Net.Pdf.Console/Off.Net.Pdf.Console.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <SonarQubeExclude>true</SonarQubeExclude>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Off.Net.Pdf.Document\Off.Net.Pdf.Document.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Off.Net.Pdf.Console/Program.cs
+++ b/src/Off.Net.Pdf.Console/Program.cs
@@ -1,0 +1,29 @@
+// <copyright file="Program.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using Off.Net.Pdf.Document;
+
+namespace Off.Net.Pdf.Console;
+
+internal static class Program
+{
+    public static async Task Main()
+    {
+        await GeneratePdf().ConfigureAwait(false);
+    }
+
+    private static async Task GeneratePdf()
+    {
+        string fileName = Path.Combine(Environment.CurrentDirectory, "off.net.pdf");
+        FileStream fileStream = new(fileName, FileMode.Create, FileAccess.Write);
+        PdfDocument pdfDocument = new(fileStream, new PdfDocumentOptions());
+
+        await using (fileStream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            await pdfDocument.GenerateOutputStream().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Off.Net.Pdf.Console/packages.lock.json
+++ b/src/Off.Net.Pdf.Console/packages.lock.json
@@ -27,6 +27,15 @@
         "type": "Transitive",
         "resolved": "1.2.0.435",
         "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
+      },
+      "off.net.pdf.core": {
+        "type": "Project"
+      },
+      "off.net.pdf.document": {
+        "type": "Project",
+        "dependencies": {
+          "Off.Net.Pdf.Core": "[1.0.0, )"
+        }
       }
     }
   }

--- a/src/Off.Net.Pdf.Core/FileStructure/FileTrailerOptions.cs
+++ b/src/Off.Net.Pdf.Core/FileStructure/FileTrailerOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FileTrailerOptions.cs" company="Sunt Programator">
+// <copyright file="FileTrailerOptions.cs" company="Sunt Programator">
 // Copyright (c) Sunt Programator. All rights reserved.
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>

--- a/src/Off.Net.Pdf.Core/Off.Net.Pdf.Core.csproj
+++ b/src/Off.Net.Pdf.Core/Off.Net.Pdf.Core.csproj
@@ -1,5 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="Properties\Resource.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Off.Net.Pdf.Document/IPdfDocumentBuilder.cs
+++ b/src/Off.Net.Pdf.Document/IPdfDocumentBuilder.cs
@@ -1,0 +1,11 @@
+// <copyright file="IPdfDocumentBuilder.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Off.Net.Pdf.Document;
+
+public interface IPdfDocumentBuilder
+{
+    PdfDocument BuildPdfDocument(Stream stream);
+}

--- a/src/Off.Net.Pdf.Document/IPdfDocumentOptions.cs
+++ b/src/Off.Net.Pdf.Document/IPdfDocumentOptions.cs
@@ -1,0 +1,10 @@
+// <copyright file="IPdfDocumentOptions.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Off.Net.Pdf.Document;
+
+public interface IPdfDocumentOptions
+{
+}

--- a/src/Off.Net.Pdf.Document/Off.Net.Pdf.Document.csproj
+++ b/src/Off.Net.Pdf.Document/Off.Net.Pdf.Document.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Off.Net.Pdf.Document/PdfDocument.cs
+++ b/src/Off.Net.Pdf.Document/PdfDocument.cs
@@ -1,0 +1,164 @@
+// <copyright file="PdfDocument.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Immutable;
+using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.DocumentStructure;
+using Off.Net.Pdf.Core.FileStructure;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text;
+using Off.Net.Pdf.Core.Text.Fonts;
+using Off.Net.Pdf.Core.Text.Operations.TextPosition;
+using Off.Net.Pdf.Core.Text.Operations.TextShowing;
+using Off.Net.Pdf.Core.Text.Operations.TextState;
+
+namespace Off.Net.Pdf.Document;
+
+public sealed class PdfDocument : IDisposable, IAsyncDisposable
+{
+    private readonly PdfIndirectIdentifier<PdfStream> contentStreamIndirect;
+    private readonly Stream stream;
+
+    // ReSharper disable once UnusedParameter.Local
+    public PdfDocument(Stream stream, IPdfDocumentOptions options)
+    {
+        int objectNumber = 0;
+        this.stream = stream;
+        this.DocumentCatalog = new PdfIndirect<DocumentCatalog>(++objectNumber).ToPdfIndirectIdentifier();
+        this.RootPageTree = new PdfIndirect<PageTreeNode>(++objectNumber).ToPdfIndirectIdentifier();
+        this.Pages = new List<PdfIndirectIdentifier<PageObject>>(1) { new PdfIndirect<PageObject>(++objectNumber).ToPdfIndirectIdentifier() }.ToImmutableList();
+        this.contentStreamIndirect = new PdfIndirect<PdfStream>(++objectNumber).ToPdfIndirectIdentifier();
+        this.Fonts = new List<PdfIndirectIdentifier<Type1Font>>(1) { new PdfIndirect<Type1Font>(++objectNumber).ToPdfIndirectIdentifier() }.ToImmutableList();
+
+        PdfOperation[] pdfOperations =
+        {
+            new FontOperation("F1", 24),
+            new MoveTextOperation(100, 100),
+            new ShowTextOperation("Hello World"),
+        };
+
+        TextObject textObject = new(pdfOperations);
+        PdfDictionary<PdfIndirectIdentifier<Type1Font>> fontDictionary = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>> { { "F1", this.Fonts[0] } }.ToPdfDictionary();
+
+        this.DocumentCatalog.PdfIndirect.Value = new DocumentCatalog(documentCatalogOptions => documentCatalogOptions.Pages = this.RootPageTree);
+        this.RootPageTree.PdfIndirect.Value = new PageTreeNode(pageTreeNodeOptions => pageTreeNodeOptions.Kids = this.Pages.ToPdfArray());
+
+        foreach (PdfIndirectIdentifier<PageObject> pageObjectIndirect in this.Pages)
+        {
+            pageObjectIndirect.PdfIndirect.Value = new PageObject(pageObjectOptions =>
+            {
+                pageObjectOptions.Parent = this.RootPageTree;
+                pageObjectOptions.MediaBox = new Rectangle(0, 0, 612, 792);
+                pageObjectOptions.Contents = this.contentStreamIndirect;
+                pageObjectOptions.Resources = new ResourceDictionary(resourceDictionaryOptions => resourceDictionaryOptions.Font = fontDictionary);
+            });
+        }
+
+        this.contentStreamIndirect.PdfIndirect.Value = new PdfStream(textObject.Content.AsMemory());
+        this.Fonts[0].PdfIndirect.Value = StandardFonts.Helvetica;
+
+        // XTable
+        int byteOffset = 0;
+        List<XRefEntry> xRefEntries = new(objectNumber) { new XRefEntry(byteOffset, 65535, XRefEntryType.Free) };
+
+        byteOffset += this.FileHeader.Length;
+        xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+
+        byteOffset += this.DocumentCatalog.PdfIndirect.Length;
+        xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+
+        byteOffset += this.RootPageTree.PdfIndirect.Length;
+        xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+
+        foreach (PdfIndirectIdentifier<PageObject> pageObjectIndirect in this.Pages)
+        {
+            byteOffset += pageObjectIndirect.PdfIndirect.Length;
+            xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+        }
+
+        byteOffset += this.contentStreamIndirect.PdfIndirect.Length;
+        xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+
+        for (int index = 0; index < this.Fonts.Count; index++)
+        {
+            PdfIndirectIdentifier<Type1Font> fontIndirect = this.Fonts[index];
+            byteOffset += fontIndirect.PdfIndirect.Length;
+
+            if (index == this.Fonts.Count - 1)
+            {
+                break;
+            }
+
+            xRefEntries.Add(new XRefEntry(byteOffset, 0, XRefEntryType.InUse));
+        }
+
+        this.XRefTable = xRefEntries.ToXRefTable(0);
+
+        this.FileTrailer = new FileTrailer(byteOffset, fileTrailerOptions =>
+        {
+            fileTrailerOptions.Size = xRefEntries.Count - 1;
+            fileTrailerOptions.Root = this.DocumentCatalog;
+        });
+    }
+
+    public PdfDocument(Stream stream, Action<IPdfDocumentOptions> options)
+        : this(stream, GetOptions(options))
+    {
+    }
+
+    public FileHeader FileHeader => FileHeader.PdfVersion17;
+
+    public PdfIndirectIdentifier<DocumentCatalog> DocumentCatalog { get; }
+
+    public PdfIndirectIdentifier<PageTreeNode> RootPageTree { get; }
+
+    public IImmutableList<PdfIndirectIdentifier<PageObject>> Pages { get; }
+
+    public IImmutableList<PdfIndirectIdentifier<Type1Font>> Fonts { get; }
+
+    public XRefTable XRefTable { get; }
+
+    public FileTrailer FileTrailer { get; }
+
+    public async Task GenerateOutputStream(CancellationToken cancellationToken = default)
+    {
+        await this.stream.WriteAsync(this.FileHeader.Bytes, cancellationToken).ConfigureAwait(false);
+        await this.stream.WriteAsync(this.DocumentCatalog.PdfIndirect.Bytes, cancellationToken).ConfigureAwait(false);
+        await this.stream.WriteAsync(this.RootPageTree.PdfIndirect.Bytes, cancellationToken).ConfigureAwait(false);
+
+        foreach (PdfIndirectIdentifier<PageObject> pageObjectIndirect in this.Pages)
+        {
+            await this.stream.WriteAsync(pageObjectIndirect.PdfIndirect.Bytes, cancellationToken).ConfigureAwait(false);
+        }
+
+        await this.stream.WriteAsync(this.contentStreamIndirect.PdfIndirect.Bytes, cancellationToken).ConfigureAwait(false);
+
+        foreach (PdfIndirectIdentifier<Type1Font> fontIndirect in this.Fonts)
+        {
+            await this.stream.WriteAsync(fontIndirect.PdfIndirect.Bytes, cancellationToken).ConfigureAwait(false);
+        }
+
+        await this.stream.WriteAsync(this.XRefTable.Bytes, cancellationToken).ConfigureAwait(false);
+        await this.stream.WriteAsync(this.FileTrailer.Bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        this.stream.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return this.stream.DisposeAsync();
+    }
+
+    private static IPdfDocumentOptions GetOptions(Action<IPdfDocumentOptions> optionsFunc)
+    {
+        PdfDocumentOptions options = new();
+        optionsFunc.Invoke(options);
+        return options;
+    }
+}

--- a/src/Off.Net.Pdf.Document/PdfDocumentBuilder.cs
+++ b/src/Off.Net.Pdf.Document/PdfDocumentBuilder.cs
@@ -1,0 +1,14 @@
+// <copyright file="PdfDocumentBuilder.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Off.Net.Pdf.Document;
+
+public sealed class PdfDocumentBuilder : IPdfDocumentBuilder
+{
+    public PdfDocument BuildPdfDocument(Stream stream)
+    {
+        return new PdfDocument(stream, _ => { });
+    }
+}

--- a/src/Off.Net.Pdf.Document/PdfDocumentOptions.cs
+++ b/src/Off.Net.Pdf.Document/PdfDocumentOptions.cs
@@ -1,0 +1,15 @@
+// <copyright file="PdfDocumentOptions.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Immutable;
+using Off.Net.Pdf.Core.DocumentStructure;
+using Off.Net.Pdf.Core.Primitives;
+
+namespace Off.Net.Pdf.Document;
+
+public sealed class PdfDocumentOptions : IPdfDocumentOptions
+{
+    public IImmutableList<PdfIndirectIdentifier<PageObject>> Pages { get; set; } = ImmutableList<PdfIndirectIdentifier<PageObject>>.Empty;
+}

--- a/src/Off.Net.Pdf.Document/packages.lock.json
+++ b/src/Off.Net.Pdf.Document/packages.lock.json
@@ -27,6 +27,9 @@
         "type": "Transitive",
         "resolved": "1.2.0.435",
         "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
+      },
+      "off.net.pdf.core": {
+        "type": "Project"
       }
     }
   }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+</Project>

--- a/tests/Off.Net.Pdf.Core.Tests/CommonDataStructures/RectangleTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/CommonDataStructures/RectangleTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RectangleTests.cs" company="Sunt Programator">
+// <copyright file="RectangleTests.cs" company="Sunt Programator">
 // Copyright (c) Sunt Programator. All rights reserved.
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>

--- a/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/DocumentCatalogTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/DocumentStructure/DocumentCatalogTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DocumentCatalogTests.cs" company="Sunt Programator">
+// <copyright file="DocumentCatalogTests.cs" company="Sunt Programator">
 // Copyright (c) Sunt Programator. All rights reserved.
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>

--- a/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/FileStructure/XRefEntryTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="XRefEntryTests.cs" company="Sunt Programator">
+// <copyright file="XRefEntryTests.cs" company="Sunt Programator">
 // Copyright (c) Sunt Programator. All rights reserved.
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>

--- a/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj
+++ b/tests/Off.Net.Pdf.Core.Tests/Off.Net.Pdf.Core.Tests.csproj
@@ -1,22 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Off.Net.Pdf.Core\Off.Net.Pdf.Core.csproj" />
   </ItemGroup>

--- a/tests/Off.Net.Pdf.Core.Tests/Text/Operations/TextShowing/ShowTextOperationTests.cs
+++ b/tests/Off.Net.Pdf.Core.Tests/Text/Operations/TextShowing/ShowTextOperationTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ShowTextOperationTests.cs" company="Sunt Programator">
+// <copyright file="ShowTextOperationTests.cs" company="Sunt Programator">
 // Copyright (c) Sunt Programator. All rights reserved.
 // Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
 // </copyright>

--- a/tests/Off.Net.Pdf.Document.Tests/Off.Net.Pdf.Document.Tests.csproj
+++ b/tests/Off.Net.Pdf.Document.Tests/Off.Net.Pdf.Document.Tests.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Off.Net.Pdf.Document\Off.Net.Pdf.Document.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Off.Net.Pdf.Document.Tests/PdfDocumentBuilderTests.cs
+++ b/tests/Off.Net.Pdf.Document.Tests/PdfDocumentBuilderTests.cs
@@ -1,0 +1,43 @@
+// <copyright file="PdfDocumentBuilderTests.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Text;
+using Xunit;
+
+namespace Off.Net.Pdf.Document.Tests;
+
+public class PdfDocumentBuilderTests
+{
+    [Fact(DisplayName = $"The {nameof(PdfDocumentBuilder)} constructor without arguments should generate a valid PDF output stream")]
+    public async Task PdfDocument_ConstructorWithoutArguments_ShouldGenerateValidOutputStream()
+    {
+        // Arrange
+        const string expectedContent =
+            "%PDF-1.7\n" +
+            "1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n" +
+            "2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n" +
+            "3 0 obj\n<</Type /Page /Parent 2 0 R /Resources <</Font <</F1 5 0 R>> /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]>> /MediaBox [0 0 612 792] /Contents 4 0 R>>\nendobj\n" +
+            "4 0 obj\n<</Length 44>>\nstream\nBT\n/F1 24 Tf\n100 100 Td\n(Hello World) Tj\nET\nendstream\nendobj\n" +
+            "5 0 obj\n<</Type /Font /Subtype /Type1 /Name /Helvetica /BaseFont /Helvetica>>\nendobj\n" +
+            "xref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000056 00000 n \n0000000111 00000 n \n0000000277 00000 n \n0000000368 00000 n \n" +
+            "trailer\n<</Size 5 /Root 1 0 R>>\n" +
+            "startxref\n453\n%%EOF";
+
+        byte[] expectedBytes = Encoding.ASCII.GetBytes(expectedContent);
+        MemoryStream stream = new();
+        IPdfDocumentBuilder pdfDocumentBuilder = new PdfDocumentBuilder();
+        PdfDocument pdfDocument = pdfDocumentBuilder.BuildPdfDocument(stream);
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            await pdfDocument.GenerateOutputStream().ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(expectedBytes, stream.ToArray());
+        }
+    }
+}

--- a/tests/Off.Net.Pdf.Document.Tests/PdfDocumentTests.cs
+++ b/tests/Off.Net.Pdf.Document.Tests/PdfDocumentTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="PdfDocumentTests.cs" company="Sunt Programator">
+// Copyright (c) Sunt Programator. All rights reserved.
+// Licensed under the GPL-3.0 license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Text;
+using Off.Net.Pdf.Core.CommonDataStructures;
+using Off.Net.Pdf.Core.ContentStreamAndResources;
+using Off.Net.Pdf.Core.DocumentStructure;
+using Off.Net.Pdf.Core.FileStructure;
+using Off.Net.Pdf.Core.Primitives;
+using Off.Net.Pdf.Core.Text.Fonts;
+using Xunit;
+
+namespace Off.Net.Pdf.Document.Tests;
+
+public class PdfDocumentTests
+{
+    [Fact(DisplayName = $"The {nameof(PdfDocument)} constructor without arguments should generate a valid PDF output stream")]
+    public async Task PdfDocument_ConstructorWithoutArguments_ShouldGenerateValidOutputStream()
+    {
+        // Arrange
+        const string expectedContent =
+            "%PDF-1.7\n" +
+            "1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n" +
+            "2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n" +
+            "3 0 obj\n<</Type /Page /Parent 2 0 R /Resources <</Font <</F1 5 0 R>> /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]>> /MediaBox [0 0 612 792] /Contents 4 0 R>>\nendobj\n" +
+            "4 0 obj\n<</Length 44>>\nstream\nBT\n/F1 24 Tf\n100 100 Td\n(Hello World) Tj\nET\nendstream\nendobj\n" +
+            "5 0 obj\n<</Type /Font /Subtype /Type1 /Name /Helvetica /BaseFont /Helvetica>>\nendobj\n" +
+            "xref\n0 6\n0000000000 65535 f \n0000000009 00000 n \n0000000056 00000 n \n0000000111 00000 n \n0000000277 00000 n \n0000000368 00000 n \n" +
+            "trailer\n<</Size 5 /Root 1 0 R>>\n" +
+            "startxref\n453\n%%EOF";
+
+        byte[] expectedBytes = Encoding.ASCII.GetBytes(expectedContent);
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, _ => { });
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            await pdfDocument.GenerateOutputStream().ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(expectedBytes, stream.ToArray());
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.FileHeader)} property should return {nameof(FileHeader.PdfVersion17)} by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_FileHeader_ShouldReturnPdf17()
+    {
+        // Arrange
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(FileHeader.PdfVersion17, pdfDocument.FileHeader);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.DocumentCatalog)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_DocumentCatalog_ShouldBePredefined()
+    {
+        // Arrange
+        var rootPageTree = new PdfIndirect<PageTreeNode>(2).ToPdfIndirectIdentifier();
+        PdfIndirectIdentifier<DocumentCatalog> expectedDocumentCatalog = new DocumentCatalog(documentCatalogOptions => documentCatalogOptions.Pages = rootPageTree)
+            .ToPdfIndirect(1)
+            .ToPdfIndirectIdentifier();
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(expectedDocumentCatalog, pdfDocument.DocumentCatalog);
+            Assert.Equal(expectedDocumentCatalog.Content, pdfDocument.DocumentCatalog.Content);
+            Assert.Equal(expectedDocumentCatalog.PdfIndirect.Content, pdfDocument.DocumentCatalog.PdfIndirect.Content);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.RootPageTree)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_RootPageTree_ShouldBePredefined()
+    {
+        // Arrange
+        var pages = new List<PdfIndirectIdentifier<PageObject>>(1) { new PdfIndirect<PageObject>(3).ToPdfIndirectIdentifier() }.ToImmutableList();
+        var expectedPageTree = new PageTreeNode(pageTreeNodeOptions => pageTreeNodeOptions.Kids = pages.ToPdfArray()).ToPdfIndirect(2).ToPdfIndirectIdentifier();
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(expectedPageTree, pdfDocument.RootPageTree);
+            Assert.Equal(expectedPageTree.Content, pdfDocument.RootPageTree.Content);
+            Assert.Equal(expectedPageTree.PdfIndirect.Content, pdfDocument.RootPageTree.PdfIndirect.Content);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.Pages)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_Pages_ShouldBePredefined()
+    {
+        // Arrange
+        PageObject pageObject = new(pageObjectOptions =>
+        {
+            pageObjectOptions.Parent = new PdfIndirect<PageTreeNode>(2).ToPdfIndirectIdentifier();
+            pageObjectOptions.MediaBox = new Rectangle(0, 0, 612, 792);
+            pageObjectOptions.Contents = new PdfIndirect<PdfStream>(4).ToPdfIndirectIdentifier();
+            pageObjectOptions.Resources = new ResourceDictionary(resourceDictionaryOptions =>
+                resourceDictionaryOptions.Font = new Dictionary<PdfName, PdfIndirectIdentifier<Type1Font>>
+                {
+                    { "F1", new PdfIndirect<Type1Font>(5).ToPdfIndirectIdentifier() },
+                }.ToPdfDictionary());
+        });
+
+        var expectedPages = new List<PdfIndirectIdentifier<PageObject>>(1)
+        {
+            pageObject.ToPdfIndirect(3).ToPdfIndirectIdentifier(),
+        }.ToImmutableList();
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(1, pdfDocument.Pages.Count);
+            Assert.Equal(expectedPages[0], pdfDocument.Pages[0]);
+            Assert.Equal(expectedPages[0].Content, pdfDocument.Pages[0].Content);
+            Assert.Equal(expectedPages[0].PdfIndirect.Content, pdfDocument.Pages[0].PdfIndirect.Content);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.Fonts)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_Fonts_ShouldBePredefined()
+    {
+        // Arrange
+        var expectedFonts = new List<PdfIndirectIdentifier<Type1Font>>(1) { StandardFonts.Helvetica.ToPdfIndirect(5).ToPdfIndirectIdentifier() }.ToImmutableList();
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Single(expectedFonts);
+            Assert.Equal(expectedFonts[0], pdfDocument.Fonts[0]);
+            Assert.Equal(expectedFonts[0].Content, pdfDocument.Fonts[0].Content);
+            Assert.Equal(expectedFonts[0].PdfIndirect.Content, pdfDocument.Fonts[0].PdfIndirect.Content);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.XRefTable)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_XRefTable_ShouldBePredefined()
+    {
+        // Arrange
+        XRefTable expectedXRefTable = new List<XRefEntry>
+        {
+            new(0, 65535, XRefEntryType.Free),
+            new(9, 0, XRefEntryType.InUse),
+            new(56, 0, XRefEntryType.InUse),
+            new(111, 0, XRefEntryType.InUse),
+            new(277, 0, XRefEntryType.InUse),
+            new(368, 0, XRefEntryType.InUse),
+        }.ToXRefTable(0);
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(expectedXRefTable, pdfDocument.XRefTable);
+            Assert.Equal(expectedXRefTable.Content, pdfDocument.XRefTable.Content);
+        }
+    }
+
+    [Fact(DisplayName = $"The {nameof(PdfDocument.FileTrailer)} property should be predefined by default")]
+    public async Task PdfDocument_ConstructorWithoutArguments_FileTrailer_ShouldBePredefined()
+    {
+        // Arrange
+        var expectedFileTrailer = new FileTrailer(453, fileTrailerOptions =>
+        {
+            fileTrailerOptions.Size = 5;
+            fileTrailerOptions.Root = new PdfIndirect<DocumentCatalog>(1).ToPdfIndirectIdentifier();
+        });
+
+        MemoryStream stream = new();
+        PdfDocument pdfDocument = new(stream, new PdfDocumentOptions());
+
+        // Act
+        await using (stream.ConfigureAwait(false))
+        await using (pdfDocument.ConfigureAwait(false))
+        {
+            // Assert
+            Assert.Equal(expectedFileTrailer.Content, pdfDocument.FileTrailer.Content);
+            Assert.Equal(expectedFileTrailer, pdfDocument.FileTrailer);
+        }
+    }
+}

--- a/tests/Off.Net.Pdf.Document.Tests/packages.lock.json
+++ b/tests/Off.Net.Pdf.Document.Tests/packages.lock.json
@@ -1044,6 +1044,12 @@
       },
       "off.net.pdf.core": {
         "type": "Project"
+      },
+      "off.net.pdf.document": {
+        "type": "Project",
+        "dependencies": {
+          "Off.Net.Pdf.Core": "[1.0.0, )"
+        }
       }
     }
   }

--- a/tools/code-coverage.ps1
+++ b/tools/code-coverage.ps1
@@ -3,16 +3,10 @@ Set-Location $PSScriptRoot\..
 try {
     dotnet test --collect:"XPlat Code Coverage"
 
-    $test_projects = ("tests\Off.Net.Pdf.Core.Tests\")
-
-    foreach ($test_project in $test_projects) {
-        $test_report_folder_object = Get-ChildItem "$test_project\TestResults" | Where-Object { $_.PSIsContainer } | Sort-Object CreationTime -desc | Select-Object -f 1
-        $test_report_folder_name = $test_report_folder_object.PSChildName
-        dotnet tool run reportgenerator `
-        -reports:"$test_project\TestResults\$test_report_folder_name\coverage.cobertura.xml" `
+    dotnet tool run reportgenerator `
+        -reports:"tests\**\TestResults\**\coverage.cobertura.xml" `
         -targetdir:"coveragereport" `
         -reporttypes:Html
-    }
 
     Invoke-Item '.\coveragereport\index.html'
 }


### PR DESCRIPTION
### Context

In order to use low-level objects from the `Core` library, there is a requirement to build a `PdfDocument` class that will help to generate a PDF document at the high-level.

This object should implement the builder pattern and support the `FluentAPI` and the Delegate as a constructor parameter in order to configure the PDF document

### Sample Design

```cs
var pdfDocument = new PdfDocumentBuilder()
  .AddPage() // Use the builder pattern to add the page properties
     .WithFontFamily("Arial")
     .WithFontSize(14)
     .WithContent("Hello, world!")
  .BuildPage()
  .AddPage(options => option.Content = "This is the second page." ) // Configure using the delegate as a param
.BuildPdfDocument();
```

### Acceptance criteria

1. Implement the `PdfDocument` object
2. The code must be covered with the unit and benchmark tests